### PR TITLE
Support appId

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,19 @@ the dashboards so you can place those wherever you'd like.
 | `<EntityLeadTimeCard />`            | Line chart showing Lead Time for the service.                         |
 | `<EntityTopContributorsTable />`    | Table showing top contributors by pull request count for the service. |
 
+## Configuration
+
+### Application Id
+
+This plugin respects the same `appId` configuration as the backend plugin to distinguish multiple instances of backstage within DX.
+Can be any string as long as it's unique within your DX account.
+
+```yaml
+# app-config.yaml
+dx:
+  appId: staging
+```
+
 ## Development
 
 `yarn install` and `yarn start` will start a local dev server showing the UI of this component. See `dev/index.tsx` for setup.

--- a/config.d.ts
+++ b/config.d.ts
@@ -1,0 +1,13 @@
+export interface Config {
+  /** Configuration options for the DX plugin */
+  dx?: {
+    /**
+     * Optional 'appId' attribute used by DX to differentiate Backstage applications.
+     * Most useful when you have multiple Backstage applications.
+     * If not provided, it will be set by DX.
+     *
+     * @visibility frontend
+     */
+    appId?: string;
+  };
+}

--- a/package.json
+++ b/package.json
@@ -63,6 +63,8 @@
     "react-router-dom": "^6.22.1"
   },
   "files": [
-    "dist"
-  ]
+    "dist",
+    "config.d.ts"
+  ],
+  "configSchema": "config.d.ts"
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,8 @@
-import { DiscoveryApi, createApiRef } from "@backstage/core-plugin-api";
+import {
+  ConfigApi,
+  DiscoveryApi,
+  createApiRef,
+} from "@backstage/core-plugin-api";
 import { ResponseError } from "@backstage/errors";
 
 export interface ChartResponse {
@@ -24,32 +28,40 @@ export const dxApiRef = createApiRef<DXApi>({
 
 export class DXApiClient implements DXApi {
   discoveryApi: DiscoveryApi;
+  configApi: ConfigApi;
 
-  constructor({ discoveryApi }: { discoveryApi: DiscoveryApi }) {
+  constructor({
+    discoveryApi,
+    configApi,
+  }: {
+    discoveryApi: DiscoveryApi;
+    configApi: ConfigApi;
+  }) {
     this.discoveryApi = discoveryApi;
+    this.configApi = configApi;
   }
 
-  changeFailureRate(entityRef: string) {
+  async changeFailureRate(entityRef: string) {
     return this.fetch<ChartResponse>(
-      `/api/backstage.changeFailureRate?entityRef=${entityRef}`,
+      `/api/backstage.changeFailureRate?entityRef=${entityRef}&appId=${this.appId()}`,
     );
   }
 
-  deploymentFrequency(entityRef: string) {
+  async deploymentFrequency(entityRef: string) {
     return this.fetch<ChartResponse>(
-      `/api/backstage.deploymentFrequency?entityRef=${entityRef}`,
+      `/api/backstage.deploymentFrequency?entityRef=${entityRef}&appId=${this.appId()}`,
     );
   }
 
-  leadTime(entityRef: string) {
+  async leadTime(entityRef: string) {
     return this.fetch<ChartResponse>(
-      `/api/backstage.leadTime?entityRef=${entityRef}`,
+      `/api/backstage.leadTime?entityRef=${entityRef}&appId=${this.appId()}`,
     );
   }
 
   topContributors(entityRef: string) {
     return this.fetch<TopContributorsResponse>(
-      `/api/backstage.topContributors?entityRef=${entityRef}`,
+      `/api/backstage.topContributors?entityRef=${entityRef}&appId=${this.appId()}`,
     );
   }
 
@@ -61,5 +73,9 @@ export class DXApiClient implements DXApi {
     if (!resp.ok) throw await ResponseError.fromResponse(resp);
 
     return await resp.json();
+  }
+
+  private appId() {
+    return this.configApi.getOptionalString("dx.appId");
   }
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -41,34 +41,49 @@ export class DXApiClient implements DXApi {
     this.configApi = configApi;
   }
 
-  async changeFailureRate(entityRef: string) {
-    return this.fetch<ChartResponse>(
-      `/api/backstage.changeFailureRate?entityRef=${entityRef}&appId=${this.appId()}`,
-    );
+  changeFailureRate(entityRef: string) {
+    return this.get<ChartResponse>("/api/backstage.changeFailureRate", {
+      entityRef,
+      appId: this.appId(),
+    });
   }
 
-  async deploymentFrequency(entityRef: string) {
-    return this.fetch<ChartResponse>(
-      `/api/backstage.deploymentFrequency?entityRef=${entityRef}&appId=${this.appId()}`,
-    );
+  deploymentFrequency(entityRef: string) {
+    return this.get<ChartResponse>("/api/backstage.deploymentFrequency", {
+      entityRef,
+      appId: this.appId(),
+    });
   }
 
-  async leadTime(entityRef: string) {
-    return this.fetch<ChartResponse>(
-      `/api/backstage.leadTime?entityRef=${entityRef}&appId=${this.appId()}`,
-    );
+  leadTime(entityRef: string) {
+    return this.get<ChartResponse>("/api/backstage.leadTime", {
+      entityRef,
+      appId: this.appId(),
+    });
   }
 
   topContributors(entityRef: string) {
-    return this.fetch<TopContributorsResponse>(
-      `/api/backstage.topContributors?entityRef=${entityRef}&appId=${this.appId()}`,
-    );
+    return this.get<TopContributorsResponse>("/api/backstage.topContributors", {
+      entityRef,
+      appId: this.appId(),
+    });
   }
 
-  private async fetch<T = any>(path: string, init?: RequestInit): Promise<T> {
-    const proxyUri = `${await this.discoveryApi.getBaseUrl("proxy")}/dx`;
+  private async get<T = any>(
+    path: string,
+    params: Record<string, string | null | undefined>,
+  ): Promise<T> {
+    const proxyHost = `${await this.discoveryApi.getBaseUrl("proxy")}/dx`;
 
-    const resp = await fetch(`${proxyUri}${path}`, init);
+    const url = new URL(`${proxyHost}${path}`);
+
+    for (const [key, value] of Object.entries(params)) {
+      if (value !== undefined && value !== null) {
+        url.searchParams.append(key, value);
+      }
+    }
+
+    const resp = await fetch(url, { method: "GET" });
 
     if (!resp.ok) throw await ResponseError.fromResponse(resp);
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,4 +1,5 @@
 import {
+  configApiRef,
   createApiFactory,
   createComponentExtension,
   createPlugin,
@@ -17,8 +18,9 @@ export const dxPlugin = createPlugin({
   apis: [
     createApiFactory({
       api: dxApiRef,
-      deps: { discoveryApi: discoveryApiRef },
-      factory: ({ discoveryApi }) => new DXApiClient({ discoveryApi }),
+      deps: { discoveryApi: discoveryApiRef, configApi: configApiRef },
+      factory: ({ discoveryApi, configApi }) =>
+        new DXApiClient({ discoveryApi, configApi }),
     }),
   ],
 });


### PR DESCRIPTION
Support app ID in the report queries so we can segment reports by backstage instance.