### PR TITLE
feat: use fetchApi to authenticate requests if needed

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -2,6 +2,7 @@ import {
   ConfigApi,
   DiscoveryApi,
   createApiRef,
+  FetchApi,
 } from "@backstage/core-plugin-api";
 import { ResponseError } from "@backstage/errors";
 
@@ -29,16 +30,20 @@ export const dxApiRef = createApiRef<DXApi>({
 export class DXApiClient implements DXApi {
   discoveryApi: DiscoveryApi;
   configApi: ConfigApi;
+  fetchApi: FetchApi;
 
   constructor({
     discoveryApi,
     configApi,
+    fetchApi,
   }: {
     discoveryApi: DiscoveryApi;
     configApi: ConfigApi;
+    fetchApi: FetchApi;
   }) {
     this.discoveryApi = discoveryApi;
     this.configApi = configApi;
+    this.fetchApi = fetchApi;
   }
 
   changeFailureRate(entityRef: string) {
@@ -82,6 +87,8 @@ export class DXApiClient implements DXApi {
         url.searchParams.append(key, value);
       }
     }
+
+    const { fetch } = this.fetchApi;
 
     const resp = await fetch(url, { method: "GET" });
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -5,6 +5,7 @@ import {
   createPlugin,
   createRoutableExtension,
   discoveryApiRef,
+  fetchApiRef,
 } from "@backstage/core-plugin-api";
 
 import { rootRouteRef } from "./routes";
@@ -18,9 +19,13 @@ export const dxPlugin = createPlugin({
   apis: [
     createApiFactory({
       api: dxApiRef,
-      deps: { discoveryApi: discoveryApiRef, configApi: configApiRef },
-      factory: ({ discoveryApi, configApi }) =>
-        new DXApiClient({ discoveryApi, configApi }),
+      deps: {
+        discoveryApi: discoveryApiRef,
+        configApi: configApiRef,
+        fetchApi: fetchApiRef,
+      },
+      factory: ({ discoveryApi, configApi, fetchApi }) =>
+        new DXApiClient({ discoveryApi, configApi, fetchApi }),
     }),
   ],
 });


### PR DESCRIPTION
This updates fetch to use the backstage provided [fetchAPI](https://backstage.io/docs/reference/core-plugin-api.fetchapi/). It will inject authentication headers required for users that [authenticate requests](https://github.com/backstage/backstage/blob/master/contrib/docs/tutorials/authenticate-api-requests.md) on the backend proxy plugin. This might change slightly in the [new backend system](https://backstage.io/docs/tutorials/auth-service-migration) (really just to be enforced by default). 