### PR TITLE
Rename LeadTime to OpenToDeploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ the dashboards so you can place those wherever you'd like.
 | `<EntityDORAMetricsConent />`       | Dashboard with all the DORA metric charts.                            |
 | `<EntityChangeFailureRateCard />`   | Line chart showing Change Failure Rate for the service.               |
 | `<EntityDeploymentFrequencyCard />` | Line chart showing Deployment Frequency for the service.              |
-| `<EntityLeadTimeCard />`            | Line chart showing Lead Time for the service.                         |
+| `<EntityOpenToDeployCard />`        | Line chart showing Open to Deploy time for the service.               |
 | `<EntityTimeToRecoveryCard />`      | Line chart showing Time to Recovery for the service.                  |
 | `<EntityTopContributorsTable />`    | Table showing top contributors by pull request count for the service. |
 

--- a/dev/index.tsx
+++ b/dev/index.tsx
@@ -150,7 +150,7 @@ const worker = setupWorker(
     }),
   ),
 
-  http.get(`${host}/api/proxy/dx/api/backstage.leadTime`, () =>
+  http.get(`${host}/api/proxy/dx/api/backstage.openToDeploy`, () =>
     HttpResponse.json({
       data: [
         {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@get-dx/backstage-plugin",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Backstage plugin for DX! https://getdx.com",
   "main": "dist/index.esm.js",
   "types": "dist/index.d.ts",

--- a/src/api.ts
+++ b/src/api.ts
@@ -19,7 +19,7 @@ export interface TopContributorsResponse {
 export interface DXApi {
   changeFailureRate(entityRef: string): Promise<ChartResponse>;
   deploymentFrequency(entityRef: string): Promise<ChartResponse>;
-  leadTime(entityRef: string): Promise<ChartResponse>;
+  openToDeploy(entityRef: string): Promise<ChartResponse>;
   timeToRecovery(entityRef: string): Promise<ChartResponse>;
   topContributors(entityRef: string): Promise<TopContributorsResponse>;
 }
@@ -61,8 +61,8 @@ export class DXApiClient implements DXApi {
     });
   }
 
-  leadTime(entityRef: string) {
-    return this.get<ChartResponse>("/api/backstage.leadTime", {
+  openToDeploy(entityRef: string) {
+    return this.get<ChartResponse>("/api/backstage.openToDeploy", {
       entityRef,
       appId: this.appId(),
     });

--- a/src/components/EntityDORAMetricsContent.tsx
+++ b/src/components/EntityDORAMetricsContent.tsx
@@ -3,7 +3,7 @@ import { Grid } from "@material-ui/core";
 import { ContentHeader, SupportButton } from "@backstage/core-components";
 import { EntityDeploymentFrequencyCard } from "../components/EntityDeploymentFrequencyCard";
 import { EntityChangeFailureRateCard } from "../components/EntityChangeFailureRateCard";
-import { EntityLeadTimeCard } from "../components/EntityLeadTimeCard";
+import { EntityOpenToDeployCard } from "../components/EntityOpenToDeployCard";
 import { EntityTimeToRecoveryCard } from "../components/EntityTimeToRecoveryCard";
 
 export function EntityDORAMetricsContent() {
@@ -11,7 +11,7 @@ export function EntityDORAMetricsContent() {
     <>
       <ContentHeader
         title="DORA"
-        description="Consolidated view of lead time, deployment frequency, and change failure rate."
+        description="Consolidated view of open to deploy, deployment frequency, and change failure rate."
       >
         <SupportButton>Dashboard for DX Dora Metrics</SupportButton>
       </ContentHeader>
@@ -26,7 +26,7 @@ export function EntityDORAMetricsContent() {
           <EntityTimeToRecoveryCard />
         </Grid>
         <Grid item md={6} xs={12}>
-          <EntityLeadTimeCard />
+          <EntityOpenToDeployCard />
         </Grid>
       </Grid>
     </>

--- a/src/components/EntityDXDashboardContent.tsx
+++ b/src/components/EntityDXDashboardContent.tsx
@@ -4,7 +4,7 @@ import Box from "@material-ui/core/Box";
 import { ContentHeader, SupportButton } from "@backstage/core-components";
 import { EntityChangeFailureRateCard } from "../components/EntityChangeFailureRateCard";
 import { EntityDeploymentFrequencyCard } from "../components/EntityDeploymentFrequencyCard";
-import { EntityLeadTimeCard } from "../components/EntityLeadTimeCard";
+import { EntityOpenToDeployCard } from "../components/EntityOpenToDeployCard";
 import { EntityTimeToRecoveryCard } from "./EntityTimeToRecoveryCard";
 import { EntityTopContributorsTable } from "../components/EntityTopContributorsTable";
 
@@ -14,7 +14,7 @@ export function EntityDXDashboardContent() {
       <Box paddingBottom="48px">
         <ContentHeader
           title="DORA"
-          description="Consolidated view of lead time, deployment frequency, and change failure rate."
+          description="Consolidated view of open to deploy, deployment frequency, and change failure rate."
         >
           <SupportButton
             items={[
@@ -42,7 +42,7 @@ export function EntityDXDashboardContent() {
             <EntityTimeToRecoveryCard />
           </Grid>
           <Grid item md={6} xs={12}>
-            <EntityLeadTimeCard />
+            <EntityOpenToDeployCard />
           </Grid>
         </Grid>
       </Box>

--- a/src/components/EntityOpenToDeployCard.tsx
+++ b/src/components/EntityOpenToDeployCard.tsx
@@ -12,7 +12,7 @@ import Tooltip from "@material-ui/core/Tooltip";
 import { dxApiRef } from "../api";
 import { LineChart } from "./LineChart";
 
-export function EntityLeadTimeCard() {
+export function EntityOpenToDeployCard() {
   const dxApi = useApi(dxApiRef);
 
   const { entity } = useEntity();
@@ -23,7 +23,7 @@ export function EntityLeadTimeCard() {
     loading,
     error,
   } = useAsync(() => {
-    return dxApi.leadTime(entityRef);
+    return dxApi.openToDeploy(entityRef);
   }, [dxApi, entityRef]);
 
   if (loading) {
@@ -38,12 +38,12 @@ export function EntityLeadTimeCard() {
     <InfoCard
       title={
         <Box display="flex" alignItems="center" gridGap="8px">
-          Lead time
+          Open to Deploy
           <Tooltip
             title={
               <Typography variant="body2">
                 This is the time between a pull request being opened and it
-                being deployed. The overall value shown is the mean.
+                being deployed. The overall value shown is the median.
               </Typography>
             }
             placement="top"

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export {
   EntityDORAMetricsContent,
   EntityDXDashboardContent,
   EntityDeploymentFrequencyCard,
+  EntityOpenToDeployCard,
   EntityLeadTimeCard,
   EntityTimeToRecoveryCard,
   EntityTopContributorsTable,

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -76,13 +76,25 @@ export const EntityDeploymentFrequencyCard = dxPlugin.provide(
   }),
 );
 
+export const EntityOpenToDeployCard = dxPlugin.provide(
+  createComponentExtension({
+    name: "EntityOpenToDeployCard",
+    component: {
+      lazy: () =>
+        import("./components/EntityOpenToDeployCard").then(
+          (m) => m.EntityOpenToDeployCard,
+        ),
+    },
+  }),
+);
+
 export const EntityLeadTimeCard = dxPlugin.provide(
   createComponentExtension({
     name: "EntityLeadTimeCard",
     component: {
       lazy: () =>
-        import("./components/EntityLeadTimeCard").then(
-          (m) => m.EntityLeadTimeCard,
+        import("./components/EntityOpenToDeployCard").then(
+          (m) => m.EntityOpenToDeployCard,
         ),
     },
   }),


### PR DESCRIPTION
For consistency with the DX product, rename LeadTime to OpenToDeploy.

Keeps LeadTime charts as an alias for backwards compatibility.