### PR TITLE
Support appId in deep links

### DIFF
--- a/dev/index.tsx
+++ b/dev/index.tsx
@@ -12,7 +12,7 @@ const mockComponentEntity: Entity = {
   apiVersion: "backstage.io/v1alpha1",
   kind: "Component",
   metadata: {
-    name: "DX App Component",
+    name: "app",
     description: "DX Application",
     annotations: {
       "github.com/project-slug": "get-dx/app",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@get-dx/backstage-plugin",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Backstage plugin for DX! https://getdx.com",
   "main": "dist/index.esm.js",
   "types": "dist/index.d.ts",

--- a/src/components/EntityChangeFailureRateCard.tsx
+++ b/src/components/EntityChangeFailureRateCard.tsx
@@ -4,7 +4,7 @@ import { stringifyEntityRef } from "@backstage/catalog-model";
 import { useEntity } from "@backstage/plugin-catalog-react";
 import useAsync from "react-use/lib/useAsync";
 import { Progress, ResponseErrorPanel } from "@backstage/core-components";
-import { useApi } from "@backstage/core-plugin-api";
+import { useApi, configApiRef } from "@backstage/core-plugin-api";
 import Typography from "@material-ui/core/Typography";
 import Box from "@material-ui/core/Box";
 import Tooltip from "@material-ui/core/Tooltip";
@@ -17,6 +17,14 @@ export function EntityChangeFailureRateCard() {
 
   const { entity } = useEntity();
   const entityRef = stringifyEntityRef(entity);
+
+  const config = useApi(configApiRef);
+  const appId = config.getOptionalString("dx.appId");
+  const deepLinkParams = new URLSearchParams({ entityRef });
+
+  if (appId) {
+    deepLinkParams.set("appId", appId);
+  }
 
   const {
     value: response,
@@ -54,7 +62,7 @@ export function EntityChangeFailureRateCard() {
         </Box>
       }
       deepLink={{
-        link: `https://app.getdx.com/datacloud/teams/backstage_dora_deep_link?entityRef=${entityRef}`,
+        link: `https://app.getdx.com/datacloud/teams/backstage_dora_deep_link?${deepLinkParams}`,
         title: "View in DX",
       }}
     >

--- a/src/components/EntityDeploymentFrequencyCard.tsx
+++ b/src/components/EntityDeploymentFrequencyCard.tsx
@@ -3,7 +3,7 @@ import { InfoCard } from "@backstage/core-components";
 import { stringifyEntityRef } from "@backstage/catalog-model";
 import { useEntity } from "@backstage/plugin-catalog-react";
 import { Progress, ResponseErrorPanel } from "@backstage/core-components";
-import { useApi } from "@backstage/core-plugin-api";
+import { useApi, configApiRef } from "@backstage/core-plugin-api";
 import InfoOutlinedIcon from "@material-ui/icons/InfoOutlined";
 import Typography from "@material-ui/core/Typography";
 import Box from "@material-ui/core/Box";
@@ -17,6 +17,14 @@ export function EntityDeploymentFrequencyCard() {
 
   const { entity } = useEntity();
   const entityRef = stringifyEntityRef(entity);
+
+  const config = useApi(configApiRef);
+  const appId = config.getOptionalString("dx.appId");
+  const deepLinkParams = new URLSearchParams({ entityRef });
+
+  if (appId) {
+    deepLinkParams.set("appId", appId);
+  }
 
   const {
     value: response,
@@ -54,7 +62,7 @@ export function EntityDeploymentFrequencyCard() {
         </Box>
       }
       deepLink={{
-        link: `https://app.getdx.com/datacloud/teams/backstage_dora_deep_link?entityRef=${entityRef}`,
+        link: `https://app.getdx.com/datacloud/teams/backstage_dora_deep_link?${deepLinkParams}`,
         title: "View in DX",
       }}
     >

--- a/src/components/EntityOpenToDeployCard.tsx
+++ b/src/components/EntityOpenToDeployCard.tsx
@@ -4,7 +4,7 @@ import { stringifyEntityRef } from "@backstage/catalog-model";
 import { useEntity } from "@backstage/plugin-catalog-react";
 import useAsync from "react-use/lib/useAsync";
 import { Progress, ResponseErrorPanel } from "@backstage/core-components";
-import { useApi } from "@backstage/core-plugin-api";
+import { useApi, configApiRef } from "@backstage/core-plugin-api";
 import InfoOutlinedIcon from "@material-ui/icons/InfoOutlined";
 import Typography from "@material-ui/core/Typography";
 import Box from "@material-ui/core/Box";
@@ -17,6 +17,14 @@ export function EntityOpenToDeployCard() {
 
   const { entity } = useEntity();
   const entityRef = stringifyEntityRef(entity);
+
+  const config = useApi(configApiRef);
+  const appId = config.getOptionalString("dx.appId");
+  const deepLinkParams = new URLSearchParams({ entityRef });
+
+  if (appId) {
+    deepLinkParams.set("appId", appId);
+  }
 
   const {
     value: response,
@@ -54,7 +62,7 @@ export function EntityOpenToDeployCard() {
         </Box>
       }
       deepLink={{
-        link: `https://app.getdx.com/datacloud/teams/backstage_dora_deep_link?entityRef=${entityRef}`,
+        link: `https://app.getdx.com/datacloud/teams/backstage_dora_deep_link?${deepLinkParams}`,
         title: "View in DX",
       }}
     >

--- a/src/components/EntityTimeToRecoveryCard.tsx
+++ b/src/components/EntityTimeToRecoveryCard.tsx
@@ -4,7 +4,7 @@ import { stringifyEntityRef } from "@backstage/catalog-model";
 import { useEntity } from "@backstage/plugin-catalog-react";
 import useAsync from "react-use/lib/useAsync";
 import { Progress, ResponseErrorPanel } from "@backstage/core-components";
-import { useApi } from "@backstage/core-plugin-api";
+import { useApi, configApiRef } from "@backstage/core-plugin-api";
 import Typography from "@material-ui/core/Typography";
 import Box from "@material-ui/core/Box";
 import Tooltip from "@material-ui/core/Tooltip";
@@ -17,6 +17,14 @@ export function EntityTimeToRecoveryCard() {
 
   const { entity } = useEntity();
   const entityRef = stringifyEntityRef(entity);
+
+  const config = useApi(configApiRef);
+  const appId = config.getOptionalString("dx.appId");
+  const deepLinkParams = new URLSearchParams({ entityRef });
+
+  if (appId) {
+    deepLinkParams.set("appId", appId);
+  }
 
   const {
     value: response,
@@ -54,7 +62,7 @@ export function EntityTimeToRecoveryCard() {
         </Box>
       }
       deepLink={{
-        link: `https://app.getdx.com/datacloud/teams/backstage_dora_deep_link?entityRef=${entityRef}`,
+        link: `https://app.getdx.com/datacloud/teams/backstage_dora_deep_link?${deepLinkParams}`,
         title: "View in DX",
       }}
     >


### PR DESCRIPTION
https://getdx.slack.com/archives/C046FQHH17U/p1723497916996749

Pass `appId` in deep links.