### PR TITLE
Add EntityScorecardsCard component

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -43,6 +43,7 @@ export type ScorecardCheck = {
     name: string;
   };
   name: string;
+  published: boolean;
   output: {
     type: OutputType;
     value: string | number | null;

--- a/src/api.ts
+++ b/src/api.ts
@@ -5,6 +5,7 @@ import {
   FetchApi,
 } from "@backstage/core-plugin-api";
 import { ResponseError } from "@backstage/errors";
+import packageJson from "../package.json";
 
 export interface ChartResponse {
   data: { label: string; value: number; date: string }[];
@@ -181,7 +182,20 @@ export class DXApiClient implements DXApi {
 
     const { fetch } = this.fetchApi;
 
-    const resp = await fetch(url, { method: "GET" });
+    const headers: Record<string, string> = {
+      "X-Client-Type": "backstage-plugin",
+      "X-Client-Version": packageJson.version,
+    };
+
+    const appId = this.appId();
+    if (appId) {
+      headers["X-DX-App-Id"] = appId;
+    }
+
+    const resp = await fetch(url, {
+      method: "GET",
+      headers,
+    });
 
     if (!resp.ok) throw await ResponseError.fromResponse(resp);
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -130,7 +130,7 @@ export class DXApiClient implements DXApi {
   }
 
   scorecards(entityIdentifier: string) {
-    return this.getFromApp<ScorecardsResponse>("/entities.scorecardsReport", {
+    return this.getFromApp<ScorecardsResponse>("/entities.scorecards", {
       identifier: entityIdentifier,
       page: "1",
       limit: "10",

--- a/src/api.ts
+++ b/src/api.ts
@@ -34,7 +34,7 @@ export type Scorecard = {
   } | null;
   id: string;
   name: string;
-}
+};
 
 export type ScorecardCheck = {
   id: string;
@@ -43,10 +43,23 @@ export type ScorecardCheck = {
     name: string;
   };
   name: string;
-  output: unknown;
+  output: {
+    type: OutputType;
+    value: string | number | null;
+  } | null;
   passed: boolean;
-  status: 'PASS' | 'FAIL' | 'WARN';
-}
+  status: "PASS" | "FAIL" | "WARN";
+};
+
+export type OutputType =
+  | "string"
+  | "number"
+  | "percent"
+  | "currency_usd"
+  | "duration_seconds"
+  | "duration_minutes"
+  | "duration_hours"
+  | "duration_days";
 
 export interface DXApi {
   changeFailureRate(entityRef: string): Promise<ChartResponse>;

--- a/src/api.ts
+++ b/src/api.ts
@@ -29,16 +29,15 @@ export interface ScorecardsResponse {
 export type Scorecard = {
   id: string;
   name: string;
-  levels: {
-    id: string;
-    name: string;
-    color: string;
-    rank: number;
-  }[];
+  empty_level: {
+    label: string | null;
+    color: string | null;
+  };
   checks: ScorecardCheck[];
   current_level: {
     id: string;
     name: string;
+    color: string;
   } | null;
 };
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -139,7 +139,6 @@ export class DXApiClient implements DXApi {
       identifier: entityIdentifier,
       page: "1",
       limit: "10",
-      // appId: this.appId(),
     });
   }
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -27,13 +27,19 @@ export interface ScorecardsResponse {
 }
 
 export type Scorecard = {
+  id: string;
+  name: string;
+  levels: {
+    id: string;
+    name: string;
+    color: string;
+    rank: number;
+  }[];
   checks: ScorecardCheck[];
   current_level: {
     id: string;
     name: string;
   } | null;
-  id: string;
-  name: string;
 };
 
 export type ScorecardCheck = {

--- a/src/components/BrandedCardTitle.tsx
+++ b/src/components/BrandedCardTitle.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import Box from "@material-ui/core/Box";
+
+export function BrandedCardTitle({
+  title,
+}: {
+  title: string | React.ReactNode;
+}) {
+  return (
+    <Box display="flex" justifyContent="space-between" alignItems="center">
+      <Box>{title}</Box>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          gridGap: 4,
+          fontSize: 12,
+          fontWeight: 400,
+          color: "#9CA3AF",
+        }}
+      >
+        <span>Powered by</span>
+        <DXLogo />
+      </Box>
+    </Box>
+  );
+}
+
+function DXLogo() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="21"
+      height="12"
+      viewBox="0 0 21 12"
+      fill="none"
+    >
+      <g clipPath="url(#clip0_8_901)">
+        <path
+          d="M17.4279 7.65054L20.457 12H17.5056C17.1857 11.6425 16.8749 11.2121 16.5998 10.8147C16.1776 10.205 16.1787 9.36824 16.6148 8.76849L17.4279 7.65054Z"
+          fill="#9CA3AF"
+        />
+        <path
+          d="M12.9229 4.34957L9.8938 6.12932e-05L12.8452 6.10352e-05C13.1651 0.357572 13.4759 0.788019 13.751 1.18538C14.1732 1.79507 14.1721 2.63189 13.7359 3.23164L12.9229 4.34957Z"
+          fill="#9CA3AF"
+        />
+        <path
+          d="M17.2338 0.737865C17.5444 0.233009 17.894 0.038835 18.4376 0.038835L20.8454 0L13.0127 11.5605C12.8428 11.8112 12.5608 11.9612 12.2593 11.9612H9.63184C12.1441 8.2116 14.8038 4.53952 17.2338 0.737865Z"
+          fill="#9CA3AF"
+        />
+        <path
+          d="M0 11.9613H4.25839C8.0659 11.9613 10.3872 9.63585 10.3872 5.99825C10.3872 2.36068 8.0659 0.0352783 4.25839 0.0352783H0L2.64078 2.37729H1.5534C0.69548 2.37729 0 3.07277 0 3.93069V9.61925V11.9613ZM2.72203 9.61925V2.37729H4.2417C6.41265 2.37729 7.6317 3.80575 7.6317 5.99825C7.6317 8.1908 6.41265 9.61925 4.25839 9.61925H2.72203Z"
+          fill="#9CA3AF"
+        />
+      </g>
+      <defs>
+        <clipPath id="clip0_8_901">
+          <rect width="21" height="12" fill="white" />
+        </clipPath>
+      </defs>
+    </svg>
+  );
+}

--- a/src/components/BrandedCardTitle.tsx
+++ b/src/components/BrandedCardTitle.tsx
@@ -1,11 +1,7 @@
 import React from "react";
 import Box from "@material-ui/core/Box";
 
-export function BrandedCardTitle({
-  title,
-}: {
-  title: string | React.ReactNode;
-}) {
+export function BrandedCardTitle({ title }: { title: string }) {
   return (
     <Box display="flex" justifyContent="space-between" alignItems="center">
       <Box>{title}</Box>

--- a/src/components/CheckResultBadge.tsx
+++ b/src/components/CheckResultBadge.tsx
@@ -1,0 +1,222 @@
+import React from "react";
+import { COLORS } from "../styles";
+
+const currencyFormatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  minimumFractionDigits: 2,
+});
+
+const CHECK_RESULT_STATUSES = {
+  PASS: "PASS",
+  WARN: "WARN",
+  FAIL: "FAIL",
+};
+
+type CheckResultStatus = keyof typeof CHECK_RESULT_STATUSES;
+
+export type CheckResultBadgeProps = {
+  status: CheckResultStatus;
+  isPublished: boolean;
+  outputEnabled: boolean;
+  outputValue: string | number | null;
+  outputType: OutputType | null;
+};
+
+type OutputType =
+  | "string"
+  | "number"
+  | "percent"
+  | "currency_usd"
+  | "duration_seconds"
+  | "duration_minutes"
+  | "duration_hours"
+  | "duration_days";
+
+export function CheckResultBadge(props: CheckResultBadgeProps) {
+  const { status, isPublished, outputEnabled, outputValue, outputType } = props;
+
+  const outputValueFormatted = formatSqlOutputValue(outputValue, outputType);
+
+  const buttonPaddingStyles = outputEnabled
+    ? { paddingLeft: 8, paddingRight: 8 }
+    : { paddingLeft: 4, paddingRight: 8 };
+
+  let badgeText = "";
+  let buttonStatusStyles = {};
+  let IconComponent = null;
+
+  if (status === CHECK_RESULT_STATUSES.PASS) {
+    badgeText = "Passed";
+    IconComponent = IconCheck;
+    buttonStatusStyles = isPublished
+      ? {
+          border: "none",
+          backgroundColor: COLORS.GREEN_50,
+          color: COLORS.GREEN_600,
+        }
+      : {
+          border: `1px dashed ${COLORS.GREEN_400}`,
+          backgroundColor: "transparent",
+          color: COLORS.GREEN_600,
+        };
+  } else if (status === CHECK_RESULT_STATUSES.WARN) {
+    badgeText = "Passed";
+    IconComponent = IconError;
+    buttonStatusStyles = isPublished
+      ? {
+          border: "none",
+          backgroundColor: COLORS.AMBER_50,
+          color: COLORS.AMBER_600,
+        }
+      : {
+          border: `1px dashed ${COLORS.AMBER_400}`,
+          backgroundColor: "transparent",
+          color: COLORS.AMBER_600,
+        };
+  } else if (status === CHECK_RESULT_STATUSES.FAIL) {
+    badgeText = "Not passed";
+    IconComponent = IconX;
+    buttonStatusStyles = isPublished
+      ? {
+          border: "none",
+          backgroundColor: COLORS.RED_50,
+          color: COLORS.RED_600,
+        }
+      : {
+          border: `1px dashed ${COLORS.RED_400}`,
+          backgroundColor: "transparent",
+          color: COLORS.RED_600,
+        };
+  } else {
+    throw new Error(`Unknown check status: ${status}`);
+  }
+
+  return (
+    <div
+      style={{
+        height: 24,
+        maxWidth: "max-content",
+        display: "flex",
+        alignItems: "center",
+        gap: "4px",
+        fontWeight: 400,
+        borderWidth: 1,
+        borderRadius: 3,
+        fontSize: 13,
+        ...buttonStatusStyles,
+        ...buttonPaddingStyles,
+      }}
+    >
+      <IconComponent />
+
+      <span
+        style={{
+          whiteSpace: "nowrap",
+          fontStyle:
+            outputEnabled && outputValue === null ? "italic" : "normal",
+        }}
+      >
+        {outputEnabled && outputValue !== null && outputValueFormatted}
+        {outputEnabled && outputValue === null && "(No data)"}
+        {!outputEnabled && badgeText}
+      </span>
+    </div>
+  );
+}
+
+function IconCheck() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="18"
+      height="18"
+      viewBox="0 0 18 18"
+      fill="none"
+    >
+      <path
+        d="M7.49998 11.6895L5.03023 9.21973L3.96973 10.2802L7.49998 13.8105L14.7802 6.53023L13.7197 5.46973L7.49998 11.6895Z"
+        fill={COLORS.GREEN_500}
+      />
+    </svg>
+  );
+}
+
+function IconError() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="18"
+      height="18"
+      viewBox="0 0 18 18"
+      fill="none"
+    >
+      <path
+        d="M8.25075 7.5H9.75075V11.25H8.25075V7.5ZM8.25 12H9.75V13.5H8.25V12Z"
+        fill={COLORS.AMBER_500}
+      />
+      <path
+        d="M10.3262 3.15002C10.0652 2.65877 9.55671 2.35352 9.00021 2.35352C8.44371 2.35352 7.93521 2.65877 7.67421 3.15077L2.17071 13.548C2.04858 13.7763 1.98809 14.0326 1.99519 14.2914C2.00229 14.5502 2.07675 14.8027 2.21121 15.024C2.34373 15.2463 2.53194 15.4302 2.75724 15.5575C2.98255 15.6848 3.23717 15.7512 3.49596 15.75H14.5045C15.0355 15.75 15.5162 15.4785 15.79 15.024C15.9242 14.8027 15.9985 14.5502 16.0056 14.2914C16.0127 14.0326 15.9524 13.7764 15.8305 13.548L10.3262 3.15002ZM3.49596 14.25L9.00021 3.85277L14.5082 14.25H3.49596Z"
+        fill={COLORS.AMBER_500}
+      />
+    </svg>
+  );
+}
+
+function IconX() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="18"
+      height="18"
+      viewBox="0 0 18 18"
+      fill="none"
+    >
+      <path
+        d="M12.144 4.758L8.96173 7.9395L5.78023 4.758L4.71973 5.8185L7.90123 9L4.71973 12.1815L5.78023 13.242L8.96173 10.0605L12.144 13.242L13.2045 12.1815L10.023 9L13.2045 5.8185L12.144 4.758Z"
+        fill={COLORS.RED_500}
+      />
+    </svg>
+  );
+}
+
+function formatSqlOutputValue(
+  outputValue: string | number | null,
+  outputType: OutputType | null
+): string | number | null {
+  if (outputValue === null) {
+    return null;
+  }
+
+  if (!outputType) {
+    return outputValue;
+  }
+
+  switch (outputType) {
+    case "string":
+      return outputValue;
+    case "number":
+      return String(outputValue);
+    case "percent": {
+      const value = Number(outputValue);
+      const rounded = Number((Math.round(value * 1000) / 1000).toFixed(3));
+      return `${rounded}%`;
+    }
+    case "duration_seconds":
+      return `${outputValue} ${pluralize("second", Number(outputValue))}`;
+    case "duration_minutes":
+      return `${outputValue} ${pluralize("minute", Number(outputValue))}`;
+    case "duration_hours":
+      return `${outputValue} ${pluralize("hour", Number(outputValue))}`;
+    case "duration_days":
+      return `${outputValue} ${pluralize("day", Number(outputValue))}`;
+    case "currency_usd":
+      return currencyFormatter.format(Number(outputValue));
+    default:
+      throw new Error(`Unknown output type: ${outputType}`);
+  }
+}
+
+function pluralize(word: string, count: number) {
+  return count === 1 ? word : `${word}s`;
+}

--- a/src/components/CheckResultBadge.tsx
+++ b/src/components/CheckResultBadge.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { COLORS } from "../styles";
+import { OutputType } from "../api";
 
 const currencyFormatter = new Intl.NumberFormat("en-US", {
   style: "currency",
@@ -23,24 +24,10 @@ export type CheckResultBadgeProps = {
   outputType: OutputType | null;
 };
 
-type OutputType =
-  | "string"
-  | "number"
-  | "percent"
-  | "currency_usd"
-  | "duration_seconds"
-  | "duration_minutes"
-  | "duration_hours"
-  | "duration_days";
-
 export function CheckResultBadge(props: CheckResultBadgeProps) {
   const { status, isPublished, outputEnabled, outputValue, outputType } = props;
 
   const outputValueFormatted = formatSqlOutputValue(outputValue, outputType);
-
-  const buttonPaddingStyles = outputEnabled
-    ? { paddingLeft: 8, paddingRight: 8 }
-    : { paddingLeft: 4, paddingRight: 8 };
 
   let badgeText = "";
   let buttonStatusStyles = {};
@@ -104,8 +91,9 @@ export function CheckResultBadge(props: CheckResultBadgeProps) {
         borderWidth: 1,
         borderRadius: 3,
         fontSize: 13,
+        paddingLeft: 4,
+        paddingRight: 8,
         ...buttonStatusStyles,
-        ...buttonPaddingStyles,
       }}
     >
       <IconComponent />

--- a/src/components/EntityScorecardsCard.tsx
+++ b/src/components/EntityScorecardsCard.tsx
@@ -10,6 +10,7 @@ import Tab from "@material-ui/core/Tab";
 
 import { dxApiRef, Scorecard, ScorecardCheck } from "../api";
 import { BrandedCardTitle } from "./BrandedCardTitle";
+import { CheckResultBadge } from "./CheckResultBadge";
 
 export function EntityScorecardsCard() {
   const dxApi = useApi(dxApiRef);
@@ -138,10 +139,41 @@ function LevelsTab({ scorecards }: { scorecards: Scorecard[] }) {
 function ChecksTab({ checks }: { checks: ScorecardCheck[] }) {
   return (
     <Box sx={{ display: "grid", gridTemplateColumns: "minmax(0, 3fr) 1fr" }}>
-      {checks.map((check) => (
+      {checks.map((check, idx) => (
         <React.Fragment key={check.id}>
-          <Box>{check.name}</Box>
-          <Box>{check.status}</Box>
+          <Box
+            sx={{
+              lineHeight: "40px",
+              fontWeight: 500,
+              fontSize: 13,
+              borderTop: idx === 0 ? "none" : "1px solid #F3F4F6",
+              paddingRight: 8,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {check.name}
+          </Box>
+          <Box
+            sx={{
+              height: "40px",
+              fontSize: 13,
+              borderTop: idx === 0 ? "none" : "1px solid #F3F4F6",
+              whiteSpace: "nowrap",
+            }}
+          >
+            <CheckResultBadge
+              status={check.status}
+              isPublished
+              // outputEnabled={check.output_enabled}
+              // outputValue={check.output_value}
+              // outputType={check.output_type}
+              outputEnabled={false}
+              outputValue={null}
+              outputType={null}
+            />
+          </Box>
         </React.Fragment>
       ))}
     </Box>

--- a/src/components/EntityScorecardsCard.tsx
+++ b/src/components/EntityScorecardsCard.tsx
@@ -170,6 +170,7 @@ function ChecksTab({ checks }: { checks: ScorecardCheck[] }) {
               height: "40px",
               display: "flex",
               alignItems: "center",
+              paddingRight: 8,
               fontSize: 13,
               borderTop: idx === 0 ? "none" : `1px solid ${COLORS.GRAY_100}`,
               whiteSpace: "nowrap",

--- a/src/components/EntityScorecardsCard.tsx
+++ b/src/components/EntityScorecardsCard.tsx
@@ -97,51 +97,55 @@ function LevelsTab({ scorecards }: { scorecards: Scorecard[] }) {
         gridTemplateColumns: "minmax(25%, 3fr) minmax(25%, 2fr)",
       }}
     >
-      {scorecards.map((scorecard, idx) => (
-        <React.Fragment key={scorecard.id}>
-          <Box
-            sx={{
-              lineHeight: "40px",
-              fontWeight: 500,
-              fontSize: 13,
-              borderTop: idx === 0 ? "none" : `1px solid ${COLORS.GRAY_100}`,
-              paddingRight: 8,
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-              whiteSpace: "nowrap",
-            }}
-          >
-            {scorecard.name}
-          </Box>
-          <Box
-            sx={{
-              display: "flex",
-              alignItems: "center",
-              fontSize: 13,
-              borderTop: idx === 0 ? "none" : `1px solid ${COLORS.GRAY_100}`,
-              whiteSpace: "nowrap",
-              color: "#616161",
-              minWidth: 0,
-            }}
-          >
-            <Box sx={{ mr: 1 }}>
-              <LevelIcon color="#FBBF24" />
-            </Box>
+      {scorecards.map((scorecard, idx) => {
+        const currentLevelDefinition = scorecard.levels.find(
+          (level) => level.id === scorecard.current_level?.id
+        );
+
+        return (
+          <React.Fragment key={scorecard.id}>
             <Box
               sx={{
+                lineHeight: "40px",
+                fontWeight: 500,
+                fontSize: 13,
+                borderTop: idx === 0 ? "none" : `1px solid ${COLORS.GRAY_100}`,
+                paddingRight: 8,
                 overflow: "hidden",
                 textOverflow: "ellipsis",
-                minWidth: 0,
                 whiteSpace: "nowrap",
               }}
             >
-              {scorecard.current_level
-                ? scorecard.current_level.name
-                : "TODO: handle no level"}
+              {scorecard.name}
             </Box>
-          </Box>
-        </React.Fragment>
-      ))}
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                fontSize: 13,
+                borderTop: idx === 0 ? "none" : `1px solid ${COLORS.GRAY_100}`,
+                whiteSpace: "nowrap",
+                color: "#616161",
+                minWidth: 0,
+              }}
+            >
+              <Box sx={{ mr: 1 }}>
+                <LevelIcon color={currentLevelDefinition?.color ?? "#ff0000"} />
+              </Box>
+              <Box
+                sx={{
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  minWidth: 0,
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {currentLevelDefinition?.name ?? "TODO: handle no level"}
+              </Box>
+            </Box>
+          </React.Fragment>
+        );
+      })}
     </Box>
   );
 }

--- a/src/components/EntityScorecardsCard.tsx
+++ b/src/components/EntityScorecardsCard.tsx
@@ -83,7 +83,7 @@ function LevelsTab({ scorecards }: { scorecards: Scorecard[] }) {
     <Box
       sx={{
         display: "grid",
-        gridTemplateColumns: "minmax(0, 3fr) 1fr",
+        gridTemplateColumns: "minmax(25%, 3fr) minmax(25%, 2fr)",
       }}
     >
       {scorecards.map((scorecard, idx) => (
@@ -95,6 +95,9 @@ function LevelsTab({ scorecards }: { scorecards: Scorecard[] }) {
               fontSize: 13,
               borderTop: idx === 0 ? "none" : "1px solid #F3F4F6",
               paddingRight: 8,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
             }}
           >
             {scorecard.name}
@@ -105,20 +108,26 @@ function LevelsTab({ scorecards }: { scorecards: Scorecard[] }) {
               alignItems: "center",
               fontSize: 13,
               borderTop: idx === 0 ? "none" : "1px solid #F3F4F6",
+              whiteSpace: "nowrap",
+              color: "#616161",
+              minWidth: 0,
             }}
           >
             <Box sx={{ mr: 1 }}>
               <LevelIcon color="#FBBF24" />
             </Box>
-            {scorecard.current_level ? (
-              <Box sx={{ whiteSpace: "nowrap", color: "#616161" }}>
-                {scorecard.current_level.name}
-              </Box>
-            ) : (
-              <Box sx={{ whiteSpace: "nowrap", color: "#616161" }}>
-                (TODO: handle no level)
-              </Box>
-            )}
+            <Box
+              sx={{
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                minWidth: 0,
+                whiteSpace: "nowrap",
+              }}
+            >
+              {scorecard.current_level
+                ? scorecard.current_level.name
+                : "TODO: handle no level"}
+            </Box>
           </Box>
         </React.Fragment>
       ))}

--- a/src/components/EntityScorecardsCard.tsx
+++ b/src/components/EntityScorecardsCard.tsx
@@ -168,12 +168,9 @@ function ChecksTab({ checks }: { checks: ScorecardCheck[] }) {
             <CheckResultBadge
               status={check.status}
               isPublished
-              // outputEnabled={check.output_enabled}
-              // outputValue={check.output_value}
-              // outputType={check.output_type}
-              outputEnabled={false}
-              outputValue={null}
-              outputType={null}
+              outputEnabled={check.output !== null}
+              outputValue={check.output?.value ?? null}
+              outputType={check.output?.type ?? null}
             />
           </Box>
         </React.Fragment>

--- a/src/components/EntityScorecardsCard.tsx
+++ b/src/components/EntityScorecardsCard.tsx
@@ -11,6 +11,7 @@ import Tab from "@material-ui/core/Tab";
 import { dxApiRef, Scorecard, ScorecardCheck } from "../api";
 import { BrandedCardTitle } from "./BrandedCardTitle";
 import { CheckResultBadge } from "./CheckResultBadge";
+import { COLORS } from "../styles";
 
 export function EntityScorecardsCard() {
   const dxApi = useApi(dxApiRef);
@@ -94,7 +95,7 @@ function LevelsTab({ scorecards }: { scorecards: Scorecard[] }) {
               lineHeight: "40px",
               fontWeight: 500,
               fontSize: 13,
-              borderTop: idx === 0 ? "none" : "1px solid #F3F4F6",
+              borderTop: idx === 0 ? "none" : `1px solid ${COLORS.GRAY_100}`,
               paddingRight: 8,
               overflow: "hidden",
               textOverflow: "ellipsis",
@@ -108,7 +109,7 @@ function LevelsTab({ scorecards }: { scorecards: Scorecard[] }) {
               display: "flex",
               alignItems: "center",
               fontSize: 13,
-              borderTop: idx === 0 ? "none" : "1px solid #F3F4F6",
+              borderTop: idx === 0 ? "none" : `1px solid ${COLORS.GRAY_100}`,
               whiteSpace: "nowrap",
               color: "#616161",
               minWidth: 0,
@@ -146,7 +147,7 @@ function ChecksTab({ checks }: { checks: ScorecardCheck[] }) {
               lineHeight: "40px",
               fontWeight: 500,
               fontSize: 13,
-              borderTop: idx === 0 ? "none" : "1px solid #F3F4F6",
+              borderTop: idx === 0 ? "none" : `1px solid ${COLORS.GRAY_100}`,
               paddingRight: 8,
               overflow: "hidden",
               textOverflow: "ellipsis",
@@ -161,7 +162,7 @@ function ChecksTab({ checks }: { checks: ScorecardCheck[] }) {
               display: "flex",
               alignItems: "center",
               fontSize: 13,
-              borderTop: idx === 0 ? "none" : "1px solid #F3F4F6",
+              borderTop: idx === 0 ? "none" : `1px solid ${COLORS.GRAY_100}`,
               whiteSpace: "nowrap",
             }}
           >

--- a/src/components/EntityScorecardsCard.tsx
+++ b/src/components/EntityScorecardsCard.tsx
@@ -81,8 +81,9 @@ export function EntityScorecardsCard({
         title: "View scorecards",
       }}
       variant="gridItem"
+      noPadding
     >
-      <Box sx={{ maxHeight: contentMaxHeight, overflow: "auto" }}>
+      <Box sx={{ maxHeight: contentMaxHeight, overflow: "auto", padding: 16 }}>
         {tab === "levels" && <LevelsTab scorecards={scorecards} />}
 
         {tab === "checks" && <ChecksTab checks={flattenedChecks} />}

--- a/src/components/EntityScorecardsCard.tsx
+++ b/src/components/EntityScorecardsCard.tsx
@@ -72,6 +72,7 @@ export function EntityScorecardsCard() {
         link: `https://app.getdx.com/catalog/${entityIdentifier}/scorecards`,
         title: "View scorecards",
       }}
+      variant="gridItem"
     >
       {tab === "levels" && <LevelsTab scorecards={scorecards} />}
 

--- a/src/components/EntityScorecardsCard.tsx
+++ b/src/components/EntityScorecardsCard.tsx
@@ -80,18 +80,44 @@ export function EntityScorecardsCard() {
 
 function LevelsTab({ scorecards }: { scorecards: Scorecard[] }) {
   return (
-    <Box sx={{ display: "grid", gridTemplateColumns: "minmax(0, 3fr) 1fr" }}>
-      {scorecards.map((scorecard) => (
+    <Box
+      sx={{
+        display: "grid",
+        gridTemplateColumns: "minmax(0, 3fr) 1fr",
+      }}
+    >
+      {scorecards.map((scorecard, idx) => (
         <React.Fragment key={scorecard.id}>
-          <Box>{scorecard.name}</Box>
-          <Box sx={{ display: "flex", alignItems: "center" }}>
-            <Box sx={{ mr: 1 }}>(icon)</Box>
+          <Box
+            sx={{
+              lineHeight: "40px",
+              fontWeight: 500,
+              fontSize: 13,
+              borderTop: idx === 0 ? "none" : "1px solid #F3F4F6",
+              paddingRight: 8,
+            }}
+          >
+            {scorecard.name}
+          </Box>
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              fontSize: 13,
+              borderTop: idx === 0 ? "none" : "1px solid #F3F4F6",
+            }}
+          >
+            <Box sx={{ mr: 1 }}>
+              <LevelIcon color="#FBBF24" />
+            </Box>
             {scorecard.current_level ? (
-              <Box sx={{ whiteSpace: "nowrap" }}>
+              <Box sx={{ whiteSpace: "nowrap", color: "#616161" }}>
                 {scorecard.current_level.name}
               </Box>
             ) : (
-              <Box sx={{ whiteSpace: "nowrap" }}>(TODO: handle no level)</Box>
+              <Box sx={{ whiteSpace: "nowrap", color: "#616161" }}>
+                (TODO: handle no level)
+              </Box>
             )}
           </Box>
         </React.Fragment>
@@ -110,5 +136,37 @@ function ChecksTab({ checks }: { checks: ScorecardCheck[] }) {
         </React.Fragment>
       ))}
     </Box>
+  );
+}
+
+export function LevelIcon({ color }: { color: string }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        borderRadius: "50%",
+        border: "1px solid",
+        width: 24,
+        height: 24,
+        color,
+        borderColor: `${color}50`,
+        backgroundColor: `${color}20`,
+      }}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        fill="none"
+      >
+        <path
+          d="M14.6314 6.11934C14.5895 5.99592 14.5124 5.88747 14.4095 5.80738C14.3067 5.72729 14.1827 5.67908 14.0527 5.66868L10.2521 5.36668L8.60739 1.72601C8.55501 1.60875 8.46982 1.50916 8.36209 1.43925C8.25436 1.36934 8.1287 1.3321 8.00027 1.33203C7.87185 1.33196 7.74615 1.36906 7.63834 1.43885C7.53054 1.50864 7.44523 1.60814 7.39272 1.72534L5.74806 5.36668L1.94739 5.66868C1.8197 5.67879 1.69762 5.72548 1.59576 5.80316C1.49391 5.88084 1.41659 5.98622 1.37305 6.1067C1.32952 6.22717 1.32162 6.35763 1.35029 6.48248C1.37896 6.60733 1.44299 6.72127 1.53472 6.81068L4.34339 9.54868L3.35006 13.85C3.3199 13.9802 3.32956 14.1165 3.3778 14.2411C3.42605 14.3657 3.51063 14.473 3.62059 14.549C3.73055 14.6249 3.8608 14.6661 3.99445 14.6671C4.12809 14.6681 4.25896 14.629 4.37006 14.5547L8.00006 12.1347L11.6301 14.5547C11.7436 14.6301 11.8775 14.6689 12.0138 14.6659C12.1501 14.6629 12.2822 14.6183 12.3923 14.538C12.5025 14.4577 12.5854 14.3456 12.6299 14.2167C12.6744 14.0879 12.6784 13.9485 12.6414 13.8173L11.4221 9.55068L14.4461 6.82934C14.6441 6.65068 14.7167 6.37201 14.6314 6.11934Z"
+          fill={color}
+        />
+      </svg>
+    </div>
   );
 }

--- a/src/components/EntityScorecardsCard.tsx
+++ b/src/components/EntityScorecardsCard.tsx
@@ -13,7 +13,13 @@ import { BrandedCardTitle } from "./BrandedCardTitle";
 import { CheckResultBadge } from "./CheckResultBadge";
 import { COLORS } from "../styles";
 
-export function EntityScorecardsCard() {
+type EntityScorecardsCardProps = {
+  contentMaxHeight?: string | number;
+};
+
+export function EntityScorecardsCard({
+  contentMaxHeight = "20rem",
+}: EntityScorecardsCardProps) {
   const dxApi = useApi(dxApiRef);
 
   const { entity } = useEntity();
@@ -74,9 +80,11 @@ export function EntityScorecardsCard() {
       }}
       variant="gridItem"
     >
-      {tab === "levels" && <LevelsTab scorecards={scorecards} />}
+      <Box sx={{ maxHeight: contentMaxHeight, overflow: "auto" }}>
+        {tab === "levels" && <LevelsTab scorecards={scorecards} />}
 
-      {tab === "checks" && <ChecksTab checks={flattenedChecks} />}
+        {tab === "checks" && <ChecksTab checks={flattenedChecks} />}
+      </Box>
     </InfoCard>
   );
 }

--- a/src/components/EntityScorecardsCard.tsx
+++ b/src/components/EntityScorecardsCard.tsx
@@ -43,6 +43,10 @@ export function EntityScorecardsCard({
   }
 
   if (error) {
+    if (error.message.includes("404")) {
+      error.message = `Failed to fetch Scorecards: entity \`${entityIdentifier}\` not found in DX Catalog`;
+    }
+
     return <ResponseErrorPanel error={error} />;
   }
 

--- a/src/components/EntityScorecardsCard.tsx
+++ b/src/components/EntityScorecardsCard.tsx
@@ -178,7 +178,7 @@ function ChecksTab({ checks }: { checks: ScorecardCheck[] }) {
           >
             <CheckResultBadge
               status={check.status}
-              isPublished
+              isPublished={check.published}
               outputEnabled={check.output !== null}
               outputValue={check.output?.value ?? null}
               outputType={check.output?.type ?? null}

--- a/src/components/EntityScorecardsCard.tsx
+++ b/src/components/EntityScorecardsCard.tsx
@@ -1,0 +1,91 @@
+import React, { useState } from "react";
+import { InfoCard } from "@backstage/core-components";
+import { useEntity } from "@backstage/plugin-catalog-react";
+import useAsync from "react-use/lib/useAsync";
+import { useApi } from "@backstage/core-plugin-api";
+import { Progress, ResponseErrorPanel } from "@backstage/core-components";
+import Box from "@material-ui/core/Box";
+import Tabs from "@material-ui/core/Tabs";
+import Tab from "@material-ui/core/Tab";
+
+import { dxApiRef, Scorecard } from "../api";
+
+export function EntityScorecardsCard() {
+  const dxApi = useApi(dxApiRef);
+
+  const { entity } = useEntity();
+
+  const entityIdentifier = entity.metadata.name;
+
+  const [tab, setTab] = useState<"levels" | "checks">("levels");
+
+  const {
+    value: response,
+    loading,
+    error,
+  } = useAsync(() => {
+    return dxApi.scorecards(entityIdentifier);
+  }, [dxApi, entityIdentifier]);
+
+  if (loading) {
+    return <Progress />;
+  }
+
+  if (error) {
+    return <ResponseErrorPanel error={error} />;
+  }
+
+  if (!response) {
+    throw new Error("Unreachable");
+  }
+
+  const scorecards = response.scorecards;
+
+  return (
+    <InfoCard
+      title={`Scorecards for ${entityIdentifier}`}
+      deepLink={{
+        link: `https://app.getdx.com/catalog/${entityIdentifier}/scorecards`,
+        title: "View scorecards",
+      }}
+    >
+      <Tabs
+        value={tab}
+        onChange={(_, value) => setTab(value)}
+        indicatorColor="primary"
+      >
+        <Tab value="levels" label="Levels" />
+        <Tab value="checks" label="Checks" />
+      </Tabs>
+      {tab === "levels" && <ScorecardLevels scorecards={scorecards} />}
+
+      {tab === "checks" && <ScorecardChecks scorecards={scorecards} />}
+    </InfoCard>
+  );
+}
+
+function ScorecardLevels({ scorecards }: { scorecards: Scorecard[] }) {
+  return (
+    <Box sx={{ display: "grid", gridTemplateColumns: "minmax(0, 3fr) 1fr" }}>
+      {scorecards.map((scorecard) => (
+        <React.Fragment key={scorecard.id}>
+          <Box>{scorecard.name}</Box>
+          <Box sx={{ display: "flex", alignItems: "center" }}>
+            <Box sx={{ mr: 1 }}>(icon)</Box>
+            {scorecard.current_level ? (
+              <Box sx={{ whiteSpace: "nowrap" }}>
+                {scorecard.current_level.name}
+              </Box>
+            ) : (
+              <Box sx={{ whiteSpace: "nowrap" }}>(TODO: handle no level)</Box>
+            )}
+          </Box>
+        </React.Fragment>
+      ))}
+    </Box>
+  );
+}
+
+function ScorecardChecks({ scorecards }: { scorecards: Scorecard[] }) {
+  return <div>Checks</div>;
+}

--- a/src/components/EntityScorecardsCard.tsx
+++ b/src/components/EntityScorecardsCard.tsx
@@ -93,6 +93,18 @@ export function EntityScorecardsCard({
 }
 
 function LevelsTab({ scorecards }: { scorecards: Scorecard[] }) {
+  if (scorecards.length === 0) {
+    return (
+      <Box
+        sx={{
+          textAlign: "center",
+        }}
+      >
+        <Box>No scorecards apply to this entity.</Box>
+      </Box>
+    );
+  }
+
   return (
     <Box
       sx={{
@@ -156,6 +168,18 @@ function LevelsTab({ scorecards }: { scorecards: Scorecard[] }) {
 }
 
 function ChecksTab({ checks }: { checks: ScorecardCheck[] }) {
+  if (checks.length === 0) {
+    return (
+      <Box
+        sx={{
+          textAlign: "center",
+        }}
+      >
+        <Box>No checks apply to this entity.</Box>
+      </Box>
+    );
+  }
+
   return (
     <Box sx={{ display: "grid", gridTemplateColumns: "minmax(0, 3fr) 1fr" }}>
       {checks.map((check, idx) => (

--- a/src/components/EntityScorecardsCard.tsx
+++ b/src/components/EntityScorecardsCard.tsx
@@ -158,6 +158,8 @@ function ChecksTab({ checks }: { checks: ScorecardCheck[] }) {
           <Box
             sx={{
               height: "40px",
+              display: "flex",
+              alignItems: "center",
               fontSize: 13,
               borderTop: idx === 0 ? "none" : "1px solid #F3F4F6",
               whiteSpace: "nowrap",

--- a/src/components/EntityScorecardsCard.tsx
+++ b/src/components/EntityScorecardsCard.tsx
@@ -8,7 +8,8 @@ import Box from "@material-ui/core/Box";
 import Tabs from "@material-ui/core/Tabs";
 import Tab from "@material-ui/core/Tab";
 
-import { dxApiRef, Scorecard } from "../api";
+import { dxApiRef, Scorecard, ScorecardCheck } from "../api";
+import { BrandedCardTitle } from "./BrandedCardTitle";
 
 export function EntityScorecardsCard() {
   const dxApi = useApi(dxApiRef);
@@ -41,30 +42,43 @@ export function EntityScorecardsCard() {
 
   const scorecards = response.scorecards;
 
+  const flattenedChecks = scorecards.flatMap((scorecard) => scorecard.checks);
+
   return (
     <InfoCard
-      title={`Scorecards for ${entityIdentifier}`}
+      title={
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            gridGap: 16,
+            marginBottom: -20,
+          }}
+        >
+          <BrandedCardTitle title="Scorecards" />
+          <Tabs
+            value={tab}
+            onChange={(_, value) => setTab(value)}
+            indicatorColor="primary"
+          >
+            <Tab value="levels" label="Levels" />
+            <Tab value="checks" label="Checks" />
+          </Tabs>
+        </Box>
+      }
       deepLink={{
         link: `https://app.getdx.com/catalog/${entityIdentifier}/scorecards`,
         title: "View scorecards",
       }}
     >
-      <Tabs
-        value={tab}
-        onChange={(_, value) => setTab(value)}
-        indicatorColor="primary"
-      >
-        <Tab value="levels" label="Levels" />
-        <Tab value="checks" label="Checks" />
-      </Tabs>
-      {tab === "levels" && <ScorecardLevels scorecards={scorecards} />}
+      {tab === "levels" && <LevelsTab scorecards={scorecards} />}
 
-      {tab === "checks" && <ScorecardChecks scorecards={scorecards} />}
+      {tab === "checks" && <ChecksTab checks={flattenedChecks} />}
     </InfoCard>
   );
 }
 
-function ScorecardLevels({ scorecards }: { scorecards: Scorecard[] }) {
+function LevelsTab({ scorecards }: { scorecards: Scorecard[] }) {
   return (
     <Box sx={{ display: "grid", gridTemplateColumns: "minmax(0, 3fr) 1fr" }}>
       {scorecards.map((scorecard) => (
@@ -86,6 +100,15 @@ function ScorecardLevels({ scorecards }: { scorecards: Scorecard[] }) {
   );
 }
 
-function ScorecardChecks({ scorecards }: { scorecards: Scorecard[] }) {
-  return <div>Checks</div>;
+function ChecksTab({ checks }: { checks: ScorecardCheck[] }) {
+  return (
+    <Box sx={{ display: "grid", gridTemplateColumns: "minmax(0, 3fr) 1fr" }}>
+      {checks.map((check) => (
+        <React.Fragment key={check.id}>
+          <Box>{check.name}</Box>
+          <Box>{check.status}</Box>
+        </React.Fragment>
+      ))}
+    </Box>
+  );
 }

--- a/src/components/EntityScorecardsCard.tsx
+++ b/src/components/EntityScorecardsCard.tsx
@@ -13,6 +13,8 @@ import { BrandedCardTitle } from "./BrandedCardTitle";
 import { CheckResultBadge } from "./CheckResultBadge";
 import { COLORS } from "../styles";
 
+const DEFAULT_NO_LEVEL_COLOR = "#CBD5E1";
+
 type EntityScorecardsCardProps = {
   contentMaxHeight?: string | number;
 };
@@ -97,55 +99,57 @@ function LevelsTab({ scorecards }: { scorecards: Scorecard[] }) {
         gridTemplateColumns: "minmax(25%, 3fr) minmax(25%, 2fr)",
       }}
     >
-      {scorecards.map((scorecard, idx) => {
-        const currentLevelDefinition = scorecard.levels.find(
-          (level) => level.id === scorecard.current_level?.id
-        );
-
-        return (
-          <React.Fragment key={scorecard.id}>
+      {scorecards.map((scorecard, idx) => (
+        <React.Fragment key={scorecard.id}>
+          <Box
+            sx={{
+              lineHeight: "40px",
+              fontWeight: 500,
+              fontSize: 13,
+              borderTop: idx === 0 ? "none" : `1px solid ${COLORS.GRAY_100}`,
+              paddingRight: 8,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {scorecard.name}
+          </Box>
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              fontSize: 13,
+              borderTop: idx === 0 ? "none" : `1px solid ${COLORS.GRAY_100}`,
+              whiteSpace: "nowrap",
+              color: "#616161",
+              minWidth: 0,
+            }}
+          >
+            <Box sx={{ mr: 1 }}>
+              <LevelIcon
+                color={
+                  scorecard.current_level?.color ??
+                  scorecard.empty_level.color ??
+                  DEFAULT_NO_LEVEL_COLOR
+                }
+              />
+            </Box>
             <Box
               sx={{
-                lineHeight: "40px",
-                fontWeight: 500,
-                fontSize: 13,
-                borderTop: idx === 0 ? "none" : `1px solid ${COLORS.GRAY_100}`,
-                paddingRight: 8,
                 overflow: "hidden",
                 textOverflow: "ellipsis",
-                whiteSpace: "nowrap",
-              }}
-            >
-              {scorecard.name}
-            </Box>
-            <Box
-              sx={{
-                display: "flex",
-                alignItems: "center",
-                fontSize: 13,
-                borderTop: idx === 0 ? "none" : `1px solid ${COLORS.GRAY_100}`,
-                whiteSpace: "nowrap",
-                color: "#616161",
                 minWidth: 0,
+                whiteSpace: "nowrap",
               }}
             >
-              <Box sx={{ mr: 1 }}>
-                <LevelIcon color={currentLevelDefinition?.color ?? "#ff0000"} />
-              </Box>
-              <Box
-                sx={{
-                  overflow: "hidden",
-                  textOverflow: "ellipsis",
-                  minWidth: 0,
-                  whiteSpace: "nowrap",
-                }}
-              >
-                {currentLevelDefinition?.name ?? "TODO: handle no level"}
-              </Box>
+              {scorecard.current_level?.name ??
+                scorecard.empty_level.label ??
+                "No level"}
             </Box>
-          </React.Fragment>
-        );
-      })}
+          </Box>
+        </React.Fragment>
+      ))}
     </Box>
   );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,5 +7,6 @@ export {
   EntityLeadTimeCard,
   EntityTimeToRecoveryCard,
   EntityTopContributorsTable,
+  EntityScorecardsCard,
   dxPlugin,
 } from "./plugin";

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -123,3 +123,15 @@ export const EntityTopContributorsTable = dxPlugin.provide(
     },
   }),
 );
+
+export const EntityScorecardsCard = dxPlugin.provide(
+  createComponentExtension({
+    name: "EntityScorecardsCard",
+    component: {
+      lazy: () =>
+        import("./components/EntityScorecardsCard").then(
+          (m) => m.EntityScorecardsCard,
+        ),
+    },
+  }),
+);

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -1,0 +1,17 @@
+export const COLORS = {
+  // Red
+  RED_50: "#FEF2F2",
+  RED_400: "#F87171",
+  RED_500: "#EF4444",
+  RED_600: "#DC2626",
+  // Amber
+  AMBER_50: "#fffbeb",
+  AMBER_400: "#fbbf24",
+  AMBER_500: "#f59e0b",
+  AMBER_600: "#d97706",
+  // Green
+  GREEN_50: "#F0FDF4",
+  GREEN_400: "#4ADE80",
+  GREEN_500: "#22C55E",
+  GREEN_600: "#16A34A",
+};

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -1,4 +1,6 @@
 export const COLORS = {
+  // Gray
+  GRAY_100: "#F3F4F6",
   // Red
   RED_50: "#FEF2F2",
   RED_400: "#F87171",


### PR DESCRIPTION
This adds a new `<EntityScorecardsCard />` component to the plugin's exports, showing info about an entity's current scorecard levels and pass/fail status on each individual check.

To use this new component, the plugin now requires a second proxy endpoint for the core DX web API, in addition to the Datacloud instance API.