### PR TITLE
Add EntityTasksCard component

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -172,7 +172,7 @@ export class DXApiClient implements DXApi {
   }
 
   tasks(entityIdentifier: string) {
-    return this.getFromApp<ScorecardsResponse>("/entities.tasks", {
+    return this.getFromApp<TasksResponse>("/entities.tasks", {
       identifier: entityIdentifier,
     });
   }

--- a/src/api.ts
+++ b/src/api.ts
@@ -71,6 +71,11 @@ export type OutputType =
 export type TasksResponse = {
   ok: true;
   tasks: Task[];
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+  };
 };
 
 export type Task = {
@@ -176,6 +181,8 @@ export class DXApiClient implements DXApi {
   tasks(entityIdentifier: string) {
     return this.getFromApp<TasksResponse>("/entities.tasks", {
       identifier: entityIdentifier,
+      page: "1",
+      limit: "50",
     });
   }
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -67,6 +67,33 @@ export type OutputType =
   | "duration_hours"
   | "duration_days";
 
+export type TasksResponse = {
+  ok: true;
+  tasks: Task[];
+};
+
+export type Task = {
+  check_description: string;
+  check_external_url: string | null;
+  check_id: string;
+  check_name: string;
+  check_public_id: string;
+  entity_check_issue_public_id: string | null;
+  entity_check_issue_url: string | null;
+  initiative_complete_by: string;
+  initiative_description: string;
+  initiative_name: string;
+  initiative_priority: number;
+  initiative_public_id: string;
+  owner: {
+    avatar: string;
+    email: string;
+    id: number;
+    name: string;
+    slack_ext_id?: string;
+  };
+};
+
 export interface DXApi {
   changeFailureRate(entityRef: string): Promise<ChartResponse>;
   deploymentFrequency(entityRef: string): Promise<ChartResponse>;
@@ -74,6 +101,7 @@ export interface DXApi {
   timeToRecovery(entityRef: string): Promise<ChartResponse>;
   topContributors(entityRef: string): Promise<TopContributorsResponse>;
   scorecards(entityIdentifier: string): Promise<ScorecardsResponse>;
+  tasks(entityIdentifier: string): Promise<TasksResponse>;
 }
 
 export const dxApiRef = createApiRef<DXApi>({
@@ -140,6 +168,12 @@ export class DXApiClient implements DXApi {
       page: "1",
       limit: "10",
       // appId: this.appId(),
+    });
+  }
+
+  tasks(entityIdentifier: string) {
+    return this.getFromApp<ScorecardsResponse>("/entities.tasks", {
+      identifier: entityIdentifier,
     });
   }
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -74,18 +74,20 @@ export type TasksResponse = {
 };
 
 export type Task = {
+  check_id: string;
   check_description: string;
   check_external_url: string | null;
-  check_id: string;
   check_name: string;
-  check_public_id: string;
-  entity_check_issue_public_id: string | null;
+
+  entity_check_issue_id: string | null;
   entity_check_issue_url: string | null;
+
+  initiative_id: string;
   initiative_complete_by: string;
   initiative_description: string;
   initiative_name: string;
   initiative_priority: number;
-  initiative_public_id: string;
+
   owner: {
     avatar: string;
     email: string;

--- a/src/components/EntityTasksCard.tsx
+++ b/src/components/EntityTasksCard.tsx
@@ -56,7 +56,7 @@ export function EntityTasksCard({
       <Box sx={{ maxHeight: contentMaxHeight, overflow: "auto", padding: 16 }}>
         {response.tasks.map((task, idx) => (
           <Box
-            key={`${task.check_public_id}-${task.initiative_public_id}`}
+            key={`${task.check_id}-${task.initiative_id}`}
             sx={{
               paddingTop: idx === 0 ? 0 : 12,
               paddingBottom: idx === response.tasks.length - 1 ? 0 : 16,

--- a/src/components/EntityTasksCard.tsx
+++ b/src/components/EntityTasksCard.tsx
@@ -112,7 +112,10 @@ function TaskSummary({ task }: { task: Task }) {
         }}
       >
         <Box>Requested by {task.owner.name}</Box>
-        <Box>Due {formattedDueDate}</Box>
+        <Box sx={{ display: "flex", alignItems: "center", gridGap: 5 }}>
+          <TimeIcon />
+          <span>Due {formattedDueDate}</span>
+        </Box>
       </Box>
     </Box>
   );
@@ -173,6 +176,27 @@ function PriorityBadge({ priority }: { priority: number }) {
       />
       <span style={{ fontSize: 11 }}>P{priority}</span>
     </div>
+  );
+}
+
+function TimeIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="12"
+      height="12"
+      viewBox="0 0 12 12"
+      fill="none"
+    >
+      <path
+        d="M6 1C3.243 1 1 3.243 1 6C1 8.757 3.243 11 6 11C8.757 11 11 8.757 11 6C11 3.243 8.757 1 6 1ZM6 10C3.7945 10 2 8.2055 2 6C2 3.7945 3.7945 2 6 2C8.2055 2 10 3.7945 10 6C10 8.2055 8.2055 10 6 10Z"
+        fill="#030712"
+      />
+      <path
+        d="M6.5 3.5H5.5V6.207L7.1465 7.8535L7.8535 7.1465L6.5 5.793V3.5Z"
+        fill="#030712"
+      />
+    </svg>
   );
 }
 

--- a/src/components/EntityTasksCard.tsx
+++ b/src/components/EntityTasksCard.tsx
@@ -135,22 +135,21 @@ function PriorityBadge({ priority }: { priority: number }) {
     };
   } else if (priority === 1) {
     badgeStyles = {
+      backgroundColor: COLORS.ORANGE_50,
+      color: COLORS.ORANGE_600,
+    };
+    indicatorStyles = {
+      backgroundColor: COLORS.ORANGE_600,
+    };
+  } else if (priority === 2) {
+    badgeStyles = {
       backgroundColor: COLORS.AMBER_50,
       color: COLORS.AMBER_600,
     };
     indicatorStyles = {
       backgroundColor: COLORS.AMBER_600,
     };
-  } else if (priority === 2) {
-    badgeStyles = {
-      backgroundColor: COLORS.GREEN_50,
-      color: COLORS.GREEN_600,
-    };
-    indicatorStyles = {
-      backgroundColor: COLORS.GREEN_600,
-    };
   }
-  // TODO: change color styles for priorities
 
   return (
     <div

--- a/src/components/EntityTasksCard.tsx
+++ b/src/components/EntityTasksCard.tsx
@@ -105,7 +105,7 @@ function TaskSummary({ task }: { task: Task }) {
       <Box
         sx={{
           display: "flex",
-          alignItems: "center",
+          alignItems: "start",
           gridGap: 16,
           fontSize: 13,
           color: COLORS.UI_GRAY_40,
@@ -114,7 +114,7 @@ function TaskSummary({ task }: { task: Task }) {
         <Box>Requested by {task.owner.name}</Box>
         <Box sx={{ display: "flex", alignItems: "center", gridGap: 5 }}>
           <TimeIcon />
-          <span>Due {formattedDueDate}</span>
+          <span style={{ whiteSpace: "nowrap" }}>Due {formattedDueDate}</span>
         </Box>
       </Box>
     </Box>
@@ -180,23 +180,15 @@ function PriorityBadge({ priority }: { priority: number }) {
 }
 
 function TimeIcon() {
+  // The SVG for this icon was having major aliasing problems, so we're inlining it as a PNG instead
   return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="12"
-      height="12"
-      viewBox="0 0 12 12"
-      fill="none"
-    >
-      <path
-        d="M6 1C3.243 1 1 3.243 1 6C1 8.757 3.243 11 6 11C8.757 11 11 8.757 11 6C11 3.243 8.757 1 6 1ZM6 10C3.7945 10 2 8.2055 2 6C2 3.7945 3.7945 2 6 2C8.2055 2 10 3.7945 10 6C10 8.2055 8.2055 10 6 10Z"
-        fill="#030712"
-      />
-      <path
-        d="M6.5 3.5H5.5V6.207L7.1465 7.8535L7.8535 7.1465L6.5 5.793V3.5Z"
-        fill="#030712"
-      />
-    </svg>
+    <img
+      src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAYAAABWdVznAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAADiSURBVHgBlZDLDsFAFIbHJWGNhC0SK8FeQkLY8U5io4+hTViIpG3UQiJpqb3iPeoNhv+0004jFv2Sycyc+38y/AtLQVb+OBeXjadzVqk1WL5YpreqbZMZPGSxXPFmq8dtx+W+/yabblhkg09ACWt1Qw4RiCQcAJsoFCWMJjOumxaXu8lVEYwYkA9mv7HzyfwrtNtpM+/xijWUq/VoHHD3njQGbkGuUKI7+1Mh/O93GnUGhnlkw0E/7oAZZdEyQjQWE4kOhCrk0I1DFGg713CtSnKtAlTBNjAvdOEt1inIUFYKPkrvLf/n5L74AAAAAElFTkSuQmCC"
+      alt="Time icon"
+      style={{
+        marginBottom: 2,
+      }}
+    />
   );
 }
 

--- a/src/components/EntityTasksCard.tsx
+++ b/src/components/EntityTasksCard.tsx
@@ -1,12 +1,186 @@
 import React from "react";
 import { InfoCard } from "@backstage/core-components";
+import { useEntity } from "@backstage/plugin-catalog-react";
+import useAsync from "react-use/lib/useAsync";
+import { useApi } from "@backstage/core-plugin-api";
+import { Progress, ResponseErrorPanel } from "@backstage/core-components";
+import Box from "@material-ui/core/Box";
 
 import { BrandedCardTitle } from "./BrandedCardTitle";
+import { dxApiRef, Task } from "../api";
+import { COLORS } from "../styles";
 
-export function EntityTasksCard() {
+type EntityTasksCardProps = {
+  contentMaxHeight?: string | number;
+};
+
+export function EntityTasksCard({
+  contentMaxHeight = "20rem",
+}: EntityTasksCardProps) {
+  const dxApi = useApi(dxApiRef);
+
+  const { entity } = useEntity();
+
+  const entityIdentifier = entity.metadata.name;
+
+  const {
+    value: response,
+    loading,
+    error,
+  } = useAsync(() => {
+    return dxApi.tasks(entityIdentifier);
+  }, [dxApi, entityIdentifier]);
+
+  if (loading) {
+    return <Progress />;
+  }
+
+  if (error) {
+    return <ResponseErrorPanel error={error} />;
+  }
+
+  if (!response) {
+    throw new Error("Unreachable");
+  }
+
   return (
-    <InfoCard title={<BrandedCardTitle title="Tasks" />} variant="gridItem">
-      Hello world
+    <InfoCard
+      title={<BrandedCardTitle title="Tasks" />}
+      deepLink={{
+        link: `https://app.getdx.com/catalog/${entityIdentifier}/tasks`,
+        title: "View tasks",
+      }}
+      variant="gridItem"
+      noPadding
+    >
+      <Box sx={{ maxHeight: contentMaxHeight, overflow: "auto", padding: 16 }}>
+        {response.tasks.map((task, idx) => (
+          <Box
+            key={`${task.check_public_id}-${task.initiative_public_id}`}
+            sx={{
+              paddingTop: idx === 0 ? 0 : 12,
+              paddingBottom: idx === response.tasks.length - 1 ? 0 : 16,
+              borderTop: idx === 0 ? "none" : `1px solid ${COLORS.GRAY_200}`,
+            }}
+          >
+            <TaskSummary task={task} />
+          </Box>
+        ))}
+      </Box>
     </InfoCard>
   );
+}
+
+function TaskSummary({ task }: { task: Task }) {
+  const formattedDueDate = formatDueDate(task.initiative_complete_by);
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gridGap: 12 }}>
+      <Box sx={{ fontWeight: 500, fontSize: 14, color: "#030712" }}>
+        {task.check_name}
+      </Box>
+      <Box>
+        <Box sx={{ display: "flex", alignItems: "center", gridGap: 8 }}>
+          <Box sx={{ fontSize: 13, fontWeight: 500, lineHeight: "20px" }}>
+            {task.initiative_name}
+          </Box>
+          <PriorityBadge priority={task.initiative_priority} />
+        </Box>
+        <div
+          style={{
+            marginTop: 2,
+            fontSize: 12,
+            color: "#7f7f7f",
+            lineHeight: "normal",
+            display: "-webkit-box",
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: "vertical",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+          }}
+        >
+          {task.initiative_description}
+        </div>
+      </Box>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          gridGap: 16,
+          fontSize: 13,
+          color: COLORS.UI_GRAY_40,
+        }}
+      >
+        <Box>Requested by {task.owner.name}</Box>
+        <Box>Due {formattedDueDate}</Box>
+      </Box>
+    </Box>
+  );
+}
+
+function PriorityBadge({ priority }: { priority: number }) {
+  let badgeStyles = {};
+  let indicatorStyles = {};
+
+  if (priority === 0) {
+    badgeStyles = {
+      backgroundColor: COLORS.RED_50,
+      color: COLORS.RED_600,
+    };
+    indicatorStyles = {
+      backgroundColor: COLORS.RED_600,
+    };
+  } else if (priority === 1) {
+    badgeStyles = {
+      backgroundColor: COLORS.AMBER_50,
+      color: COLORS.AMBER_600,
+    };
+    indicatorStyles = {
+      backgroundColor: COLORS.AMBER_600,
+    };
+  } else if (priority === 2) {
+    badgeStyles = {
+      backgroundColor: COLORS.GREEN_50,
+      color: COLORS.GREEN_600,
+    };
+    indicatorStyles = {
+      backgroundColor: COLORS.GREEN_600,
+    };
+  }
+  // TODO: change color styles for priorities
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gridGap: 4,
+        paddingLeft: 4,
+        paddingRight: 4,
+        borderRadius: 2,
+        lineHeight: "13px",
+        ...badgeStyles,
+      }}
+    >
+      <div
+        style={{
+          width: 4,
+          height: 4,
+          borderRadius: 24,
+          marginBottom: 1,
+          ...indicatorStyles,
+        }}
+      />
+      <span style={{ fontSize: 11 }}>P{priority}</span>
+    </div>
+  );
+}
+
+function formatDueDate(date: string): string {
+  return new Date(date).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
 }

--- a/src/components/EntityTasksCard.tsx
+++ b/src/components/EntityTasksCard.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { InfoCard } from "@backstage/core-components";
+
+import { BrandedCardTitle } from "./BrandedCardTitle";
+
+export function EntityTasksCard() {
+  return (
+    <InfoCard title={<BrandedCardTitle title="Tasks" />} variant="gridItem">
+      Hello world
+    </InfoCard>
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,5 +8,6 @@ export {
   EntityTimeToRecoveryCard,
   EntityTopContributorsTable,
   EntityScorecardsCard,
+  EntityTasksCard,
   dxPlugin,
 } from "./plugin";

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -135,3 +135,13 @@ export const EntityScorecardsCard = dxPlugin.provide(
     },
   }),
 );
+
+export const EntityTasksCard = dxPlugin.provide(
+  createComponentExtension({
+    name: "EntityTasksCard",
+    component: {
+      lazy: () =>
+        import("./components/EntityTasksCard").then((m) => m.EntityTasksCard),
+    },
+  }),
+);

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -1,6 +1,7 @@
 export const COLORS = {
   // Gray
   GRAY_100: "#F3F4F6",
+  GRAY_200: "#E5E7EB",
   // Red
   RED_50: "#FEF2F2",
   RED_400: "#F87171",
@@ -16,4 +17,6 @@ export const COLORS = {
   GREEN_400: "#4ADE80",
   GREEN_500: "#22C55E",
   GREEN_600: "#16A34A",
+  // Material UI gray
+  UI_GRAY_40: "#616161",
 };

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -7,6 +7,9 @@ export const COLORS = {
   RED_400: "#F87171",
   RED_500: "#EF4444",
   RED_600: "#DC2626",
+  // Orange
+  ORANGE_50: "#fff7ed",
+  ORANGE_600: "#ea580c",
   // Amber
   AMBER_50: "#fffbeb",
   AMBER_400: "#fbbf24",


### PR DESCRIPTION
This adds a new <EntityTasksCard /> component to the plugin's exports, showing info about an entity's currently failing initiative tasks.

Depends on https://github.com/get-dx/backstage-plugin/pull/17.

<img width="423" alt="image" src="https://github.com/user-attachments/assets/3f6eccec-36e8-4059-9b70-934bddbb1bac" />
