### PR TITLE
Bump version to 0.7.0-beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@get-dx/backstage-plugin",
-  "version": "0.6.0",
+  "version": "0.7.0-beta.2",
   "description": "Backstage plugin for DX! https://getdx.com",
   "main": "dist/index.esm.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
This bumps the plugin version to `0.7.0-beta.2`. We'll continue developing on this branch until scorecards-related components are ready for use, then we'll merge to `main` and publish `0.7.0`.