### PR TITLE
Add EntityTasksPage component

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -101,13 +101,15 @@ export type Task = {
   initiative_name: string;
   initiative_priority: number;
 
-  owner: {
-    avatar: string;
-    email: string;
-    id: number;
-    name: string;
-    slack_ext_id?: string;
-  };
+  owner: User;
+};
+
+export type User = {
+  avatar: string;
+  email: string;
+  id: number;
+  name: string;
+  slack_ext_id?: string;
 };
 
 export interface DXApi {

--- a/src/components/EntityScorecardsPage.tsx
+++ b/src/components/EntityScorecardsPage.tsx
@@ -4,6 +4,7 @@ import {
   Progress,
   ResponseErrorPanel,
   SupportButton,
+  BottomLink,
 } from "@backstage/core-components";
 import { useApi } from "@backstage/core-plugin-api";
 import { useEntity } from "@backstage/plugin-catalog-react";
@@ -107,6 +108,10 @@ function ScorecardSummary({
   isOpen: boolean;
   onOpenChange: (isOpen: boolean) => void;
 }) {
+  const { entity } = useEntity();
+  const entityIdentifier = entity.metadata.name;
+  const entityScorecardUrl = `https://app.getdx.com/catalog/${entityIdentifier}/scorecards?expanded=${scorecard.id}`;
+
   const totalChecks = scorecard.checks.length;
   const passedChecks = scorecard.checks.filter(
     (check) => check.passed === true
@@ -200,111 +205,116 @@ function ScorecardSummary({
       </div>
 
       {isOpen && (
-        <Box sx={{ borderTop: `1px solid ${COLORS.GRAY_200}` }}>
-          {scorecard.levels.map((level, levelIdx) => {
-            const levelChecks = scorecard.checks.filter(
-              (check) => check.level.id === level.id
-            );
+        <>
+          <Box sx={{ borderTop: `1px solid ${COLORS.GRAY_200}` }}>
+            {scorecard.levels.map((level, levelIdx) => {
+              const levelChecks = scorecard.checks.filter(
+                (check) => check.level.id === level.id
+              );
 
-            return (
-              <Box key={level.id}>
-                <Box
-                  sx={{
-                    height: 48,
-                    display: "flex",
-                    alignItems: "center",
-                    gridGap: 8,
-                    paddingLeft: 12,
-                    paddingRight: 12,
-                  }}
-                >
+              return (
+                <Box key={level.id}>
                   <Box
                     sx={{
+                      height: 48,
                       display: "flex",
                       alignItems: "center",
-                      justifyContent: "center",
+                      gridGap: 8,
+                      paddingLeft: 12,
+                      paddingRight: 12,
                     }}
                   >
-                    <LevelIcon color={level.color} />
-                  </Box>
-                  <Box sx={{ fontSize: 14, fontWeight: 700 }}>{level.name}</Box>
-                </Box>
-                <Box
-                  sx={{
-                    paddingLeft: 36,
-                    paddingRight: 12,
-                    paddingBottom: 8,
-                    borderBottom:
-                      levelIdx < scorecard.levels.length - 1
-                        ? `1px solid ${COLORS.GRAY_200}`
-                        : "none",
-                  }}
-                >
-                  {levelChecks.map((check, checkIdx) => (
                     <Box
-                      key={check.id}
                       sx={{
                         display: "flex",
-                        flexDirection: "row",
                         alignItems: "center",
-                        gridGap: 8,
-                        padding: 8,
-                        borderBottom:
-                          checkIdx < levelChecks.length - 1
-                            ? `1px solid ${COLORS.GRAY_200}`
-                            : "none",
+                        justifyContent: "center",
                       }}
                     >
-                      <Box sx={{ flex: 1 }}>
-                        <Box sx={{ fontSize: 13, fontWeight: 500 }}>
-                          {check.name}
-                        </Box>
-                        <Box
-                          sx={{
-                            fontSize: 13,
-                            fontWeight: 400,
-                            color: "#7f7f7f",
-                          }}
-                        >
-                          {check.description}
-                        </Box>
-                      </Box>
-                      <Box>
-                        {check.executed_at && (
+                      <LevelIcon color={level.color} />
+                    </Box>
+                    <Box sx={{ fontSize: 14, fontWeight: 700 }}>
+                      {level.name}
+                    </Box>
+                  </Box>
+                  <Box
+                    sx={{
+                      paddingLeft: 36,
+                      paddingRight: 12,
+                      paddingBottom: 8,
+                      borderBottom:
+                        levelIdx < scorecard.levels.length - 1
+                          ? `1px solid ${COLORS.GRAY_200}`
+                          : "none",
+                    }}
+                  >
+                    {levelChecks.map((check, checkIdx) => (
+                      <Box
+                        key={check.id}
+                        sx={{
+                          display: "flex",
+                          flexDirection: "row",
+                          alignItems: "center",
+                          gridGap: 8,
+                          padding: 8,
+                          borderBottom:
+                            checkIdx < levelChecks.length - 1
+                              ? `1px solid ${COLORS.GRAY_200}`
+                              : "none",
+                        }}
+                      >
+                        <Box sx={{ flex: 1 }}>
+                          <Box sx={{ fontSize: 13, fontWeight: 500 }}>
+                            {check.name}
+                          </Box>
                           <Box
                             sx={{
                               fontSize: 13,
-                              color: COLORS.GRAY_400,
-                              display: "flex",
-                              alignItems: "center",
-                              gridGap: 4,
+                              fontWeight: 400,
+                              color: "#7f7f7f",
                             }}
                           >
-                            <TimeIcon />
-                            <span>
-                              {DateTime.fromISO(check.executed_at, {
-                                zone: "utc",
-                              }).toRelative()}
-                            </span>
+                            {check.description}
                           </Box>
-                        )}
+                        </Box>
+                        <Box>
+                          {check.executed_at && (
+                            <Box
+                              sx={{
+                                fontSize: 13,
+                                color: COLORS.GRAY_400,
+                                display: "flex",
+                                alignItems: "center",
+                                gridGap: 4,
+                              }}
+                            >
+                              <TimeIcon />
+                              <span>
+                                {DateTime.fromISO(check.executed_at, {
+                                  zone: "utc",
+                                }).toRelative()}
+                              </span>
+                            </Box>
+                          )}
+                        </Box>
+                        <Box>
+                          <CheckResultBadge
+                            status={check.status}
+                            isPublished={check.published}
+                            outputEnabled={!!check.output}
+                            outputValue={check.output?.value ?? null}
+                            outputType={check.output?.type ?? null}
+                          />
+                        </Box>
                       </Box>
-                      <Box>
-                        <CheckResultBadge
-                          status={check.status}
-                          isPublished={check.published}
-                          outputEnabled={!!check.output}
-                          outputValue={check.output?.value ?? null}
-                          outputType={check.output?.type ?? null}
-                        />
-                      </Box>
-                    </Box>
-                  ))}
+                    ))}
+                  </Box>
                 </Box>
-              </Box>
-            );
-          })}
-        </Box>
+              );
+            })}
+          </Box>
+          <BottomLink link={entityScorecardUrl} title="View scorecard in DX" />
+        </>
       )}
     </Card>
   );

--- a/src/components/EntityTasksCard.tsx
+++ b/src/components/EntityTasksCard.tsx
@@ -8,7 +8,7 @@ import Box from "@material-ui/core/Box";
 
 import { BrandedCardTitle } from "./Branding";
 import { dxApiRef, Task } from "../api";
-import { COLORS } from "../styles";
+import { COLORS, TASK_PRIORITY_COLORS } from "../styles";
 
 type EntityTasksCardProps = {
   contentMaxHeight?: string | number;
@@ -122,34 +122,14 @@ function TaskSummary({ task }: { task: Task }) {
 }
 
 function PriorityBadge({ priority }: { priority: number }) {
-  let badgeStyles = {};
-  let indicatorStyles = {};
-
-  if (priority === 0) {
-    badgeStyles = {
-      backgroundColor: COLORS.RED_50,
-      color: COLORS.RED_600,
-    };
-    indicatorStyles = {
-      backgroundColor: COLORS.RED_600,
-    };
-  } else if (priority === 1) {
-    badgeStyles = {
-      backgroundColor: COLORS.ORANGE_50,
-      color: COLORS.ORANGE_600,
-    };
-    indicatorStyles = {
-      backgroundColor: COLORS.ORANGE_600,
-    };
-  } else if (priority === 2) {
-    badgeStyles = {
-      backgroundColor: COLORS.AMBER_50,
-      color: COLORS.AMBER_600,
-    };
-    indicatorStyles = {
-      backgroundColor: COLORS.AMBER_600,
-    };
-  }
+  const { bg, fg } = TASK_PRIORITY_COLORS[priority];
+  const badgeStyles = {
+    backgroundColor: bg,
+    color: fg,
+  };
+  const indicatorStyles = {
+    backgroundColor: fg,
+  };
 
   return (
     <div

--- a/src/components/EntityTasksCard.tsx
+++ b/src/components/EntityTasksCard.tsx
@@ -5,6 +5,8 @@ import useAsync from "react-use/lib/useAsync";
 import { useApi } from "@backstage/core-plugin-api";
 import { Progress, ResponseErrorPanel } from "@backstage/core-components";
 import Box from "@material-ui/core/Box";
+import ScheduleIcon from "@material-ui/icons/Schedule";
+import { DateTime } from "luxon";
 
 import { BrandedCardTitle } from "./Branding";
 import { dxApiRef, Task } from "../api";
@@ -73,6 +75,7 @@ export function EntityTasksCard({
 
 function TaskSummary({ task }: { task: Task }) {
   const formattedDueDate = formatDueDate(task.initiative_complete_by);
+  const dueDateStatusColor = getDueDateStatusColor(task.initiative_complete_by);
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gridGap: 12 }}>
@@ -112,8 +115,15 @@ function TaskSummary({ task }: { task: Task }) {
         }}
       >
         <Box>Requested by {task.owner.name}</Box>
-        <Box sx={{ display: "flex", alignItems: "center", gridGap: 5 }}>
-          <TimeIcon />
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            gridGap: 5,
+            color: dueDateStatusColor,
+          }}
+        >
+          <ScheduleIcon style={{ fontSize: 12, marginBottom: 2 }} />
           <span style={{ whiteSpace: "nowrap" }}>Due {formattedDueDate}</span>
         </Box>
       </Box>
@@ -158,19 +168,6 @@ function PriorityBadge({ priority }: { priority: number }) {
   );
 }
 
-function TimeIcon() {
-  // The SVG for this icon was having major aliasing problems, so we're inlining it as a PNG instead
-  return (
-    <img
-      src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAYAAABWdVznAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAADiSURBVHgBlZDLDsFAFIbHJWGNhC0SK8FeQkLY8U5io4+hTViIpG3UQiJpqb3iPeoNhv+0004jFv2Sycyc+38y/AtLQVb+OBeXjadzVqk1WL5YpreqbZMZPGSxXPFmq8dtx+W+/yabblhkg09ACWt1Qw4RiCQcAJsoFCWMJjOumxaXu8lVEYwYkA9mv7HzyfwrtNtpM+/xijWUq/VoHHD3njQGbkGuUKI7+1Mh/O93GnUGhnlkw0E/7oAZZdEyQjQWE4kOhCrk0I1DFGg713CtSnKtAlTBNjAvdOEt1inIUFYKPkrvLf/n5L74AAAAAElFTkSuQmCC"
-      alt="Time icon"
-      style={{
-        marginBottom: 2,
-      }}
-    />
-  );
-}
-
 function formatDueDate(date: string): string {
   return new Date(date).toLocaleDateString(undefined, {
     month: "short",
@@ -178,4 +175,18 @@ function formatDueDate(date: string): string {
     year: "numeric",
     timeZone: "UTC",
   });
+}
+
+function getDueDateStatusColor(dueDate: string): string {
+  const dueDateDate = DateTime.fromISO(dueDate, { zone: "utc" });
+  const today = DateTime.now();
+  const diff = dueDateDate.diff(today, ["days"]).days;
+
+  if (diff < 0) {
+    return COLORS.RED_500;
+  } else if (diff < 14) {
+    return COLORS.AMBER_500;
+  }
+
+  return COLORS.GRAY_500;
 }

--- a/src/components/EntityTasksPage.tsx
+++ b/src/components/EntityTasksPage.tsx
@@ -8,12 +8,12 @@ import {
 import { useApi } from "@backstage/core-plugin-api";
 import { useEntity } from "@backstage/plugin-catalog-react";
 import Box from "@material-ui/core/Box";
-// import Card from "@material-ui/core/Card";
+import Card from "@material-ui/core/Card";
 import Grid from "@material-ui/core/Grid";
 import useAsync from "react-use/lib/useAsync";
 
-import { dxApiRef } from "../api";
-// import { COLORS } from "../styles";
+import { dxApiRef, Task } from "../api";
+import { COLORS } from "../styles";
 import { PoweredByDX } from "./Branding";
 
 export function EntityTasksPage() {
@@ -74,10 +74,192 @@ export function EntityTasksPage() {
         </ContentHeader>
       </Box>
       <Grid container spacing={3} alignItems="stretch">
-        <div>
-          <pre>{JSON.stringify(tasks, null, 2)}</pre>
-        </div>
+        {[0, 1, 2].map((priorityLevel) => (
+          <Grid item xs={12} key={priorityLevel}>
+            <PriorityTaskList
+              priorityLevel={priorityLevel}
+              tasks={tasks.filter(
+                (task) => task.initiative_priority === priorityLevel
+              )}
+            />
+          </Grid>
+        ))}
       </Grid>
     </>
   );
+}
+
+function PriorityTaskList({
+  priorityLevel,
+  tasks,
+}: {
+  priorityLevel: number;
+  tasks: Task[];
+}) {
+  if (tasks.length === 0) {
+    return null;
+  }
+
+  return (
+    <Card>
+      <Box
+        sx={{
+          height: 60,
+          paddingLeft: 24,
+          paddingRight: 24,
+          display: "flex",
+          alignItems: "center",
+          gridGap: 8,
+          borderBottom: `1px solid ${COLORS.GRAY_200}`,
+        }}
+      >
+        <PriorityIndicator priorityLevel={priorityLevel} />
+        <Box
+          sx={{
+            fontSize: 22,
+            fontWeight: 700,
+            letterSpacing: "-0.25px",
+            lineHeight: "normal",
+          }}
+        >
+          P{priorityLevel}
+        </Box>
+      </Box>
+      <Box>
+        {tasks.map((task) => (
+          <Box
+            key={`${task.check_id}-${task.initiative_id}`}
+            sx={{ borderBottom: `1px solid ${COLORS.GRAY_200}` }}
+          >
+            <TaskSummary task={task} />
+          </Box>
+        ))}
+      </Box>
+      <Box
+        sx={{
+          paddingLeft: 24,
+          paddingRight: 24,
+          paddingTop: 12,
+          paddingBottom: 12,
+        }}
+      >
+        TODO: View tasks in DX
+      </Box>
+    </Card>
+  );
+}
+
+function PriorityIndicator({ priorityLevel }: { priorityLevel: number }) {
+  // TODO: Move to styles, use from EntityTasksCard too
+  const PRIORITY_COLORS: Record<number, { bg: string; fg: string }> = {
+    0: {
+      bg: COLORS.RED_50,
+      fg: COLORS.RED_600,
+    },
+    1: {
+      bg: COLORS.ORANGE_50,
+      fg: COLORS.ORANGE_600,
+    },
+    2: {
+      bg: COLORS.AMBER_50,
+      fg: COLORS.AMBER_600,
+    },
+  };
+
+  const indicatorColor = PRIORITY_COLORS[priorityLevel].fg;
+  return (
+    <div
+      style={{
+        width: 8,
+        height: 8,
+        borderRadius: 24,
+        marginBottom: 1,
+        backgroundColor: indicatorColor,
+      }}
+    />
+  );
+}
+
+function TaskSummary({ task }: { task: Task }) {
+  const formattedDueDate = formatDueDate(task.initiative_complete_by);
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "row",
+        alignItems: "center",
+        gridGap: 16,
+        padding: 16,
+      }}
+    >
+      <Box
+        sx={{ flex: 1, display: "flex", flexDirection: "column", gridGap: 12 }}
+      >
+        <Box sx={{ fontWeight: 500, fontSize: 14, color: "#030712" }}>
+          {task.check_name}
+        </Box>
+        <Box>
+          <Box sx={{ fontSize: 13, fontWeight: 500, lineHeight: "20px" }}>
+            {task.initiative_name}
+          </Box>
+          <div
+            style={{
+              marginTop: 2,
+              fontSize: 12,
+              color: "#7f7f7f",
+              lineHeight: "normal",
+              display: "-webkit-box",
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: "vertical",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+            }}
+          >
+            {task.initiative_description}
+          </div>
+        </Box>
+      </Box>
+
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "start",
+          gridGap: 16,
+          fontSize: 13,
+          color: COLORS.UI_GRAY_40,
+          whiteSpace: "nowrap",
+        }}
+      >
+        <Box>Requested by {task.owner.name}</Box>
+        <Box sx={{ display: "flex", alignItems: "center", gridGap: 5 }}>
+          <TimeIcon />
+          <span style={{ whiteSpace: "nowrap" }}>Due {formattedDueDate}</span>
+        </Box>
+      </Box>
+    </Box>
+  );
+}
+
+// TODO: Extract and reuse
+function TimeIcon() {
+  // The SVG for this icon was having major aliasing problems, so we're inlining it as a PNG instead
+  return (
+    <img
+      src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAYAAABWdVznAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAADiSURBVHgBlZDLDsFAFIbHJWGNhC0SK8FeQkLY8U5io4+hTViIpG3UQiJpqb3iPeoNhv+0004jFv2Sycyc+38y/AtLQVb+OBeXjadzVqk1WL5YpreqbZMZPGSxXPFmq8dtx+W+/yabblhkg09ACWt1Qw4RiCQcAJsoFCWMJjOumxaXu8lVEYwYkA9mv7HzyfwrtNtpM+/xijWUq/VoHHD3njQGbkGuUKI7+1Mh/O93GnUGhnlkw0E/7oAZZdEyQjQWE4kOhCrk0I1DFGg713CtSnKtAlTBNjAvdOEt1inIUFYKPkrvLf/n5L74AAAAAElFTkSuQmCC"
+      alt="Time icon"
+      style={{
+        marginBottom: 2,
+      }}
+    />
+  );
+}
+
+function formatDueDate(date: string): string {
+  return new Date(date).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
 }

--- a/src/components/EntityTasksPage.tsx
+++ b/src/components/EntityTasksPage.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import {
   ContentHeader,
   Progress,
@@ -8,6 +8,7 @@ import {
 import { useApi } from "@backstage/core-plugin-api";
 import { useEntity } from "@backstage/plugin-catalog-react";
 import Box from "@material-ui/core/Box";
+import Button from "@material-ui/core/Button";
 import Card from "@material-ui/core/Card";
 import Grid from "@material-ui/core/Grid";
 import useAsync from "react-use/lib/useAsync";
@@ -183,6 +184,9 @@ function PriorityIndicator({ priorityLevel }: { priorityLevel: number }) {
 function TaskSummary({ task }: { task: Task }) {
   const formattedDueDate = formatDueDate(task.initiative_complete_by);
 
+  const [checkDescriptionExpanded, setCheckDescriptionExpanded] =
+    useState(false);
+
   return (
     <Box
       sx={{
@@ -196,9 +200,41 @@ function TaskSummary({ task }: { task: Task }) {
       <Box
         sx={{ flex: 1, display: "flex", flexDirection: "column", gridGap: 12 }}
       >
-        <Box sx={{ fontWeight: 500, fontSize: 14, color: "#030712" }}>
-          {task.check_name}
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "row",
+            alignItems: "center",
+            gridGap: 4,
+            fontWeight: 500,
+            fontSize: 14,
+            color: "#030712",
+          }}
+        >
+          <Box>{task.check_name}</Box>
+          <Button
+            onClick={() =>
+              setCheckDescriptionExpanded(!checkDescriptionExpanded)
+            }
+            size="small"
+          >
+            Expand
+          </Button>
         </Box>
+        {checkDescriptionExpanded && (
+          <Box
+            sx={{
+              border: `1px solid ${COLORS.GRAY_200}`,
+              borderRadius: 6,
+              paddingTop: 4,
+              paddingBottom: 4,
+              paddingLeft: 8,
+              paddingRight: 8,
+            }}
+          >
+            {task.check_description}
+          </Box>
+        )}
         <Box>
           <Box sx={{ fontSize: 13, fontWeight: 500, lineHeight: "20px" }}>
             {task.initiative_name}

--- a/src/components/EntityTasksPage.tsx
+++ b/src/components/EntityTasksPage.tsx
@@ -12,7 +12,7 @@ import Card from "@material-ui/core/Card";
 import Grid from "@material-ui/core/Grid";
 import useAsync from "react-use/lib/useAsync";
 
-import { dxApiRef, Task } from "../api";
+import { dxApiRef, Task, User } from "../api";
 import { COLORS } from "../styles";
 import { PoweredByDX } from "./Branding";
 
@@ -210,7 +210,7 @@ function TaskSummary({ task }: { task: Task }) {
               color: "#7f7f7f",
               lineHeight: "normal",
               display: "-webkit-box",
-              WebkitLineClamp: 2,
+              WebkitLineClamp: 1,
               WebkitBoxOrient: "vertical",
               overflow: "hidden",
               textOverflow: "ellipsis",
@@ -224,19 +224,49 @@ function TaskSummary({ task }: { task: Task }) {
       <Box
         sx={{
           display: "flex",
-          alignItems: "start",
+          alignItems: "center",
           gridGap: 16,
           fontSize: 13,
           color: COLORS.UI_GRAY_40,
           whiteSpace: "nowrap",
         }}
       >
-        <Box>Requested by {task.owner.name}</Box>
+        <Box sx={{ display: "flex", alignItems: "center", gridGap: 8 }}>
+          Requested by
+          <UserChip user={task.owner} />
+        </Box>
         <Box sx={{ display: "flex", alignItems: "center", gridGap: 5 }}>
           <TimeIcon />
           <span style={{ whiteSpace: "nowrap" }}>Due {formattedDueDate}</span>
         </Box>
       </Box>
+    </Box>
+  );
+}
+
+function UserChip({ user }: { user: User }) {
+  return (
+    <Box
+      sx={{
+        height: 24,
+        paddingLeft: 4,
+        paddingRight: 8,
+        display: "flex",
+        alignItems: "center",
+        gridGap: 8,
+        border: `1px solid ${COLORS.GRAY_200}`,
+        borderRadius: 24,
+        fontSize: 12,
+        fontWeight: 500,
+        color: COLORS.GRAY_700,
+      }}
+    >
+      <img
+        src={user.avatar}
+        alt={`${user.name}`}
+        style={{ display: "block", height: 16, width: 16, borderRadius: 32 }}
+      />
+      <Box>{user.name}</Box>
     </Box>
   );
 }

--- a/src/components/EntityTasksPage.tsx
+++ b/src/components/EntityTasksPage.tsx
@@ -284,6 +284,9 @@ function TaskSummary({ task }: { task: Task }) {
           <TimeIcon />
           <span style={{ whiteSpace: "nowrap" }}>Due {formattedDueDate}</span>
         </Box>
+        <Box>
+          <ChevronRightIcon style={{ color: COLORS.GRAY_300, fontSize: 24 }} />
+        </Box>
       </Box>
     </Box>
   );

--- a/src/components/EntityTasksPage.tsx
+++ b/src/components/EntityTasksPage.tsx
@@ -17,7 +17,7 @@ import ChevronRightIcon from "@material-ui/icons/ChevronRight";
 import useAsync from "react-use/lib/useAsync";
 
 import { dxApiRef, Task, User } from "../api";
-import { COLORS } from "../styles";
+import { COLORS, TASK_PRIORITY_COLORS } from "../styles";
 import { PoweredByDX } from "./Branding";
 
 export function EntityTasksPage() {
@@ -151,23 +151,7 @@ function PriorityTaskList({
 }
 
 function PriorityIndicator({ priorityLevel }: { priorityLevel: number }) {
-  // TODO: Move to styles, use from EntityTasksCard too
-  const PRIORITY_COLORS: Record<number, { bg: string; fg: string }> = {
-    0: {
-      bg: COLORS.RED_50,
-      fg: COLORS.RED_600,
-    },
-    1: {
-      bg: COLORS.ORANGE_50,
-      fg: COLORS.ORANGE_600,
-    },
-    2: {
-      bg: COLORS.AMBER_50,
-      fg: COLORS.AMBER_600,
-    },
-  };
-
-  const indicatorColor = PRIORITY_COLORS[priorityLevel].fg;
+  const indicatorColor = TASK_PRIORITY_COLORS[priorityLevel].fg;
   return (
     <div
       style={{

--- a/src/components/EntityTasksPage.tsx
+++ b/src/components/EntityTasksPage.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import {
+  ContentHeader,
+  Progress,
+  ResponseErrorPanel,
+  SupportButton,
+} from "@backstage/core-components";
+import { useApi } from "@backstage/core-plugin-api";
+import { useEntity } from "@backstage/plugin-catalog-react";
+import Box from "@material-ui/core/Box";
+// import Card from "@material-ui/core/Card";
+import Grid from "@material-ui/core/Grid";
+import useAsync from "react-use/lib/useAsync";
+
+import { dxApiRef } from "../api";
+// import { COLORS } from "../styles";
+import { PoweredByDX } from "./Branding";
+
+export function EntityTasksPage() {
+  const dxApi = useApi(dxApiRef);
+
+  const { entity } = useEntity();
+
+  const entityIdentifier = entity.metadata.name;
+
+  const {
+    value: response,
+    loading,
+    error,
+  } = useAsync(() => {
+    return dxApi.tasks(entityIdentifier);
+  }, [dxApi, entityIdentifier]);
+
+  if (loading) {
+    return <Progress />;
+  }
+
+  if (error) {
+    if (error.message.includes("404")) {
+      error.message = `Failed to fetch tasks: entity \`${entityIdentifier}\` not found in DX Catalog`;
+    }
+
+    return <ResponseErrorPanel error={error} />;
+  }
+
+  if (!response) {
+    throw new Error("Unreachable");
+  }
+
+  const tasks = response.tasks;
+
+  return (
+    <>
+      <Box paddingBottom="48px">
+        <ContentHeader
+          title="Tasks"
+          description="View the required tasks for this service that align with organization-wide initiatives."
+        >
+          <PoweredByDX />
+          <SupportButton
+            items={[
+              {
+                title: "Dashboard for DX Tasks",
+                icon: "chat",
+                links: [
+                  {
+                    url: "https://help.getdx.com/en/",
+                    title: "DX Help Center",
+                  },
+                ],
+              },
+            ]}
+          />
+        </ContentHeader>
+      </Box>
+      <Grid container spacing={3} alignItems="stretch">
+        <div>
+          <pre>{JSON.stringify(tasks, null, 2)}</pre>
+        </div>
+      </Grid>
+    </>
+  );
+}

--- a/src/components/EntityTasksPage.tsx
+++ b/src/components/EntityTasksPage.tsx
@@ -14,7 +14,9 @@ import Card from "@material-ui/core/Card";
 import Grid from "@material-ui/core/Grid";
 import Link from "@material-ui/core/Link";
 import ChevronRightIcon from "@material-ui/icons/ChevronRight";
+import ScheduleIcon from "@material-ui/icons/Schedule";
 import useAsync from "react-use/lib/useAsync";
+import { DateTime } from "luxon";
 
 import { dxApiRef, Task, User } from "../api";
 import { COLORS, TASK_PRIORITY_COLORS } from "../styles";
@@ -170,10 +172,11 @@ function TaskSummary({ task }: { task: Task }) {
   const entityIdentifier = entity.metadata.name;
   const entityTasksUrl = `https://app.getdx.com/catalog/${entityIdentifier}/tasks`;
 
-  const formattedDueDate = formatDueDate(task.initiative_complete_by);
-
   const [checkDescriptionExpanded, setCheckDescriptionExpanded] =
     useState(false);
+
+  const formattedDueDate = formatDueDate(task.initiative_complete_by);
+  const dueDateStatusColor = getDueDateStatusColor(task.initiative_complete_by);
 
   return (
     <Link
@@ -278,8 +281,15 @@ function TaskSummary({ task }: { task: Task }) {
             Requested by
             <UserChip user={task.owner} />
           </Box>
-          <Box sx={{ display: "flex", alignItems: "center", gridGap: 5 }}>
-            <TimeIcon />
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              gridGap: 5,
+              color: dueDateStatusColor,
+            }}
+          >
+            <ScheduleIcon style={{ fontSize: 12, marginBottom: 2 }} />
             <span style={{ whiteSpace: "nowrap" }}>Due {formattedDueDate}</span>
           </Box>
           <Box>
@@ -320,20 +330,6 @@ function UserChip({ user }: { user: User }) {
   );
 }
 
-// TODO: Extract and reuse
-function TimeIcon() {
-  // The SVG for this icon was having major aliasing problems, so we're inlining it as a PNG instead
-  return (
-    <img
-      src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAYAAABWdVznAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAADiSURBVHgBlZDLDsFAFIbHJWGNhC0SK8FeQkLY8U5io4+hTViIpG3UQiJpqb3iPeoNhv+0004jFv2Sycyc+38y/AtLQVb+OBeXjadzVqk1WL5YpreqbZMZPGSxXPFmq8dtx+W+/yabblhkg09ACWt1Qw4RiCQcAJsoFCWMJjOumxaXu8lVEYwYkA9mv7HzyfwrtNtpM+/xijWUq/VoHHD3njQGbkGuUKI7+1Mh/O93GnUGhnlkw0E/7oAZZdEyQjQWE4kOhCrk0I1DFGg713CtSnKtAlTBNjAvdOEt1inIUFYKPkrvLf/n5L74AAAAAElFTkSuQmCC"
-      alt="Time icon"
-      style={{
-        marginBottom: 2,
-      }}
-    />
-  );
-}
-
 function formatDueDate(date: string): string {
   return new Date(date).toLocaleDateString(undefined, {
     month: "short",
@@ -341,4 +337,18 @@ function formatDueDate(date: string): string {
     year: "numeric",
     timeZone: "UTC",
   });
+}
+
+function getDueDateStatusColor(dueDate: string): string {
+  const dueDateDate = DateTime.fromISO(dueDate, { zone: "utc" });
+  const today = DateTime.now();
+  const diff = dueDateDate.diff(today, ["days"]).days;
+
+  if (diff < 0) {
+    return COLORS.RED_500;
+  } else if (diff < 14) {
+    return COLORS.AMBER_500;
+  }
+
+  return COLORS.GRAY_500;
 }

--- a/src/components/EntityTasksPage.tsx
+++ b/src/components/EntityTasksPage.tsx
@@ -8,9 +8,10 @@ import {
 import { useApi } from "@backstage/core-plugin-api";
 import { useEntity } from "@backstage/plugin-catalog-react";
 import Box from "@material-ui/core/Box";
-import Button from "@material-ui/core/Button";
+import IconButton from "@material-ui/core/IconButton";
 import Card from "@material-ui/core/Card";
 import Grid from "@material-ui/core/Grid";
+import ChevronRightIcon from "@material-ui/icons/ChevronRight";
 import useAsync from "react-use/lib/useAsync";
 
 import { dxApiRef, Task, User } from "../api";
@@ -212,14 +213,22 @@ function TaskSummary({ task }: { task: Task }) {
           }}
         >
           <Box>{task.check_name}</Box>
-          <Button
+          <IconButton
             onClick={() =>
               setCheckDescriptionExpanded(!checkDescriptionExpanded)
             }
             size="small"
           >
-            Expand
-          </Button>
+            <ChevronRightIcon
+              style={{
+                opacity: 0.6,
+                fontSize: 18,
+                transform: checkDescriptionExpanded
+                  ? "rotate(-90deg)"
+                  : "rotate(90deg)",
+              }}
+            />
+          </IconButton>
         </Box>
         {checkDescriptionExpanded && (
           <Box

--- a/src/components/EntityTasksPage.tsx
+++ b/src/components/EntityTasksPage.tsx
@@ -4,6 +4,7 @@ import {
   Progress,
   ResponseErrorPanel,
   SupportButton,
+  BottomLink,
 } from "@backstage/core-components";
 import { useApi } from "@backstage/core-plugin-api";
 import { useEntity } from "@backstage/plugin-catalog-react";
@@ -11,6 +12,7 @@ import Box from "@material-ui/core/Box";
 import IconButton from "@material-ui/core/IconButton";
 import Card from "@material-ui/core/Card";
 import Grid from "@material-ui/core/Grid";
+import Link from "@material-ui/core/Link";
 import ChevronRightIcon from "@material-ui/icons/ChevronRight";
 import useAsync from "react-use/lib/useAsync";
 
@@ -98,6 +100,10 @@ function PriorityTaskList({
   priorityLevel: number;
   tasks: Task[];
 }) {
+  const { entity } = useEntity();
+  const entityIdentifier = entity.metadata.name;
+  const entityTasksUrl = `https://app.getdx.com/catalog/${entityIdentifier}/tasks`;
+
   if (tasks.length === 0) {
     return null;
   }
@@ -128,25 +134,18 @@ function PriorityTaskList({
         </Box>
       </Box>
       <Box>
-        {tasks.map((task) => (
+        {tasks.map((task, idx) => (
           <Box
             key={`${task.check_id}-${task.initiative_id}`}
-            sx={{ borderBottom: `1px solid ${COLORS.GRAY_200}` }}
+            sx={{
+              borderTop: idx === 0 ? "none" : `1px solid ${COLORS.GRAY_200}`,
+            }}
           >
             <TaskSummary task={task} />
           </Box>
         ))}
       </Box>
-      <Box
-        sx={{
-          paddingLeft: 24,
-          paddingRight: 24,
-          paddingTop: 12,
-          paddingBottom: 12,
-        }}
-      >
-        TODO: View tasks in DX
-      </Box>
+      <BottomLink link={entityTasksUrl} title="View tasks in DX" />
     </Card>
   );
 }
@@ -183,112 +182,130 @@ function PriorityIndicator({ priorityLevel }: { priorityLevel: number }) {
 }
 
 function TaskSummary({ task }: { task: Task }) {
+  const { entity } = useEntity();
+  const entityIdentifier = entity.metadata.name;
+  const entityTasksUrl = `https://app.getdx.com/catalog/${entityIdentifier}/tasks`;
+
   const formattedDueDate = formatDueDate(task.initiative_complete_by);
 
   const [checkDescriptionExpanded, setCheckDescriptionExpanded] =
     useState(false);
 
   return (
-    <Box
-      sx={{
-        display: "flex",
-        flexDirection: "row",
-        alignItems: "center",
-        gridGap: 16,
-        padding: 16,
-      }}
+    <Link
+      href={entityTasksUrl}
+      target="_blank"
+      style={{ textDecoration: "none", color: "#181818" }}
     >
-      <Box
-        sx={{ flex: 1, display: "flex", flexDirection: "column", gridGap: 12 }}
-      >
-        <Box
-          sx={{
-            display: "flex",
-            flexDirection: "row",
-            alignItems: "center",
-            gridGap: 4,
-            fontWeight: 500,
-            fontSize: 14,
-            color: "#030712",
-          }}
-        >
-          <Box>{task.check_name}</Box>
-          <IconButton
-            onClick={() =>
-              setCheckDescriptionExpanded(!checkDescriptionExpanded)
-            }
-            size="small"
-          >
-            <ChevronRightIcon
-              style={{
-                opacity: 0.6,
-                fontSize: 18,
-                transform: checkDescriptionExpanded
-                  ? "rotate(-90deg)"
-                  : "rotate(90deg)",
-              }}
-            />
-          </IconButton>
-        </Box>
-        {checkDescriptionExpanded && (
-          <Box
-            sx={{
-              border: `1px solid ${COLORS.GRAY_200}`,
-              borderRadius: 6,
-              paddingTop: 4,
-              paddingBottom: 4,
-              paddingLeft: 8,
-              paddingRight: 8,
-            }}
-          >
-            {task.check_description}
-          </Box>
-        )}
-        <Box>
-          <Box sx={{ fontSize: 13, fontWeight: 500, lineHeight: "20px" }}>
-            {task.initiative_name}
-          </Box>
-          <div
-            style={{
-              marginTop: 2,
-              fontSize: 12,
-              color: "#7f7f7f",
-              lineHeight: "normal",
-              display: "-webkit-box",
-              WebkitLineClamp: 1,
-              WebkitBoxOrient: "vertical",
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-            }}
-          >
-            {task.initiative_description}
-          </div>
-        </Box>
-      </Box>
-
       <Box
         sx={{
           display: "flex",
+          flexDirection: "row",
           alignItems: "center",
           gridGap: 16,
-          fontSize: 13,
-          color: COLORS.UI_GRAY_40,
-          whiteSpace: "nowrap",
+          padding: 16,
         }}
       >
-        <Box sx={{ display: "flex", alignItems: "center", gridGap: 8 }}>
-          Requested by
-          <UserChip user={task.owner} />
+        <Box
+          sx={{
+            flex: 1,
+            display: "flex",
+            flexDirection: "column",
+            gridGap: 12,
+          }}
+        >
+          <Box
+            sx={{
+              display: "flex",
+              flexDirection: "row",
+              alignItems: "center",
+              gridGap: 4,
+              fontWeight: 500,
+              fontSize: 14,
+              color: "#030712",
+            }}
+          >
+            <Box>{task.check_name}</Box>
+            <IconButton
+              onClick={(e) => {
+                e.preventDefault();
+                setCheckDescriptionExpanded(!checkDescriptionExpanded);
+              }}
+              size="small"
+            >
+              <ChevronRightIcon
+                style={{
+                  opacity: 0.6,
+                  fontSize: 18,
+                  transform: checkDescriptionExpanded
+                    ? "rotate(-90deg)"
+                    : "rotate(90deg)",
+                }}
+              />
+            </IconButton>
+          </Box>
+          {checkDescriptionExpanded && (
+            <Box
+              sx={{
+                border: `1px solid ${COLORS.GRAY_200}`,
+                borderRadius: 6,
+                paddingTop: 4,
+                paddingBottom: 4,
+                paddingLeft: 8,
+                paddingRight: 8,
+              }}
+            >
+              {task.check_description}
+            </Box>
+          )}
+          <Box>
+            <Box sx={{ fontSize: 13, fontWeight: 500, lineHeight: "20px" }}>
+              {task.initiative_name}
+            </Box>
+            <div
+              style={{
+                marginTop: 2,
+                fontSize: 12,
+                color: "#7f7f7f",
+                lineHeight: "normal",
+                display: "-webkit-box",
+                WebkitLineClamp: 1,
+                WebkitBoxOrient: "vertical",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+              }}
+            >
+              {task.initiative_description}
+            </div>
+          </Box>
         </Box>
-        <Box sx={{ display: "flex", alignItems: "center", gridGap: 5 }}>
-          <TimeIcon />
-          <span style={{ whiteSpace: "nowrap" }}>Due {formattedDueDate}</span>
-        </Box>
-        <Box>
-          <ChevronRightIcon style={{ color: COLORS.GRAY_300, fontSize: 24 }} />
+
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            gridGap: 16,
+            fontSize: 13,
+            color: COLORS.UI_GRAY_40,
+            whiteSpace: "nowrap",
+          }}
+        >
+          <Box sx={{ display: "flex", alignItems: "center", gridGap: 8 }}>
+            Requested by
+            <UserChip user={task.owner} />
+          </Box>
+          <Box sx={{ display: "flex", alignItems: "center", gridGap: 5 }}>
+            <TimeIcon />
+            <span style={{ whiteSpace: "nowrap" }}>Due {formattedDueDate}</span>
+          </Box>
+          <Box>
+            <ChevronRightIcon
+              style={{ color: COLORS.GRAY_300, fontSize: 24 }}
+            />
+          </Box>
         </Box>
       </Box>
-    </Box>
+    </Link>
   );
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,5 +10,6 @@ export {
   EntityScorecardsCard,
   EntityTasksCard,
   EntityScorecardsPage,
+  EntityTasksPage,
   dxPlugin,
 } from "./plugin";

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -156,3 +156,12 @@ export const EntityScorecardsPage = dxPlugin.provide(
     mountPoint: rootRouteRef,
   }),
 );
+
+export const EntityTasksPage = dxPlugin.provide(
+  createRoutableExtension({
+    name: "EntityTasksPage",
+    component: () =>
+      import("./components/EntityTasksPage").then((m) => m.EntityTasksPage),
+    mountPoint: rootRouteRef,
+  }),
+);

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -29,3 +29,19 @@ export const COLORS = {
 };
 
 export const DEFAULT_NO_LEVEL_COLOR = "#CBD5E1";
+
+export const TASK_PRIORITY_COLORS: Record<number, { bg: string; fg: string }> =
+  {
+    0: {
+      bg: COLORS.RED_50,
+      fg: COLORS.RED_600,
+    },
+    1: {
+      bg: COLORS.ORANGE_50,
+      fg: COLORS.ORANGE_600,
+    },
+    2: {
+      bg: COLORS.AMBER_50,
+      fg: COLORS.AMBER_600,
+    },
+  };

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -2,6 +2,7 @@ export const COLORS = {
   // Gray
   GRAY_100: "#F3F4F6",
   GRAY_200: "#E5E7EB",
+  GRAY_300: "#D1D5DB",
   GRAY_400: "#9CA3AF",
   GRAY_500: "#6B7280",
   GRAY_700: "#374151",

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -4,6 +4,7 @@ export const COLORS = {
   GRAY_200: "#E5E7EB",
   GRAY_400: "#9CA3AF",
   GRAY_500: "#6B7280",
+  GRAY_700: "#374151",
   // Red
   RED_50: "#FEF2F2",
   RED_400: "#F87171",


### PR DESCRIPTION
## Overview

This defines a new `<EntityTasksPage />` component, to show outstanding tasks for a single entity, grouped by priority.

The PR includes a couple of bonus changes:

- Adds due date status colors to the `<EntityTasksCard />` because I missed them earlier
- Adds a bottom link to `<EntityScorecardsPage />` because I missed it earlier and now I know how to add them

## Screenshots

### Default

<img width="1493" alt="image" src="https://github.com/user-attachments/assets/4a40b125-05c9-4381-8260-81c8d3548116" />

### Check description expanded

<img width="1494" alt="image" src="https://github.com/user-attachments/assets/3fcb124e-4524-43cb-9e06-efdb5f8f972a" />
