### PR TITLE
Add support for Points-based Scorecards

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.7.0-beta.7",
   "description": "Backstage plugin for DX! https://getdx.com",
   "main": "dist/index.esm.js",
+  "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
   "repository": {
     "type": "git",

--- a/src/api.ts
+++ b/src/api.ts
@@ -58,7 +58,8 @@ export type PointsBasedScorecard = {
   name: string;
   checks: PointsBasedScorecardCheck[];
 
-  check_groups: ScorecardCheckGroup[];
+  // TODO: rename
+  groups: ScorecardCheckGroup[];
 };
 
 export type ScorecardCheckGroup = {

--- a/src/api.ts
+++ b/src/api.ts
@@ -27,20 +27,24 @@ export interface ScorecardsResponse {
   };
 }
 
-export type Scorecard = {
+export type Scorecard = LevelBasedScorecard | PointsBasedScorecard;
+
+export type LevelBasedScorecard = {
   id: string;
+  type: "LEVEL";
   name: string;
-  empty_level: {
-    label: string | null;
-    color: string | null;
-  };
-  checks: ScorecardCheck[];
+  checks: LevelBasedScorecardCheck[];
+
   levels: {
     id: string;
     name: string;
     color: string;
     rank: number;
   }[];
+  empty_level: {
+    label: string | null;
+    color: string | null;
+  };
   current_level: {
     id: string;
     name: string;
@@ -48,12 +52,26 @@ export type Scorecard = {
   } | null;
 };
 
-export type ScorecardCheck = {
+export type PointsBasedScorecard = {
   id: string;
-  level: {
-    id: string;
-    name: string;
-  };
+  type: "POINTS";
+  name: string;
+  checks: PointsBasedScorecardCheck[];
+
+  check_groups: ScorecardCheckGroup[];
+};
+
+export type ScorecardCheckGroup = {
+  id: string;
+  name: string;
+};
+
+export type ScorecardCheck =
+  | LevelBasedScorecardCheck
+  | PointsBasedScorecardCheck;
+
+export type PointsBasedScorecardCheck = {
+  id: string;
   name: string;
   description: string;
   published: boolean;
@@ -64,6 +82,30 @@ export type ScorecardCheck = {
   passed: boolean;
   status: "PASS" | "FAIL" | "WARN";
   executed_at: string | null;
+
+  group: {
+    id: string;
+    name: string;
+  };
+};
+
+export type LevelBasedScorecardCheck = {
+  id: string;
+  name: string;
+  description: string;
+  published: boolean;
+  output: {
+    type: OutputType;
+    value: string | number | null;
+  } | null;
+  passed: boolean;
+  status: "PASS" | "FAIL" | "WARN";
+  executed_at: string | null;
+
+  level: {
+    id: string;
+    name: string;
+  };
 };
 
 export type OutputType =

--- a/src/api.ts
+++ b/src/api.ts
@@ -58,8 +58,11 @@ export type PointsBasedScorecard = {
   name: string;
   checks: PointsBasedScorecardCheck[];
 
-  // TODO: rename
-  groups: ScorecardCheckGroup[];
+  points_meta: {
+    points_achieved: number;
+    points_total: number;
+  };
+  check_groups: ScorecardCheckGroup[];
 };
 
 export type ScorecardCheckGroup = {
@@ -84,7 +87,8 @@ export type PointsBasedScorecardCheck = {
   status: "PASS" | "FAIL" | "WARN";
   executed_at: string | null;
 
-  group: {
+  points: number;
+  check_group: {
     id: string;
     name: string;
   };

--- a/src/components/EntityScorecardsCard.tsx
+++ b/src/components/EntityScorecardsCard.tsx
@@ -13,6 +13,7 @@ import { BrandedCardTitle } from "./Branding";
 import { CheckResultBadge } from "./CheckResultBadge";
 import { COLORS, DEFAULT_NO_LEVEL_COLOR } from "../styles";
 import { LevelIcon } from "./LevelIcon";
+import { RadialProgressIndicator } from "./RadialProgressIndicator";
 
 type EntityScorecardsCardProps = {
   contentMaxHeight?: string | number;
@@ -170,7 +171,20 @@ function LevelsTab({ scorecards }: { scorecards: Scorecard[] }) {
               </>
             )}
 
-            {scorecard.type === "POINTS" && <Box>TODO: PBS info</Box>}
+            {scorecard.type === "POINTS" && (
+              <>
+                <Box sx={{ marginRight: 8 }}>
+                  <RadialProgressIndicator
+                    numerator={scorecard.points_meta.points_achieved}
+                    denominator={scorecard.points_meta.points_total}
+                  />
+                </Box>
+                <Box>
+                  {scorecard.points_meta.points_achieved} /{" "}
+                  {scorecard.points_meta.points_total} points
+                </Box>
+              </>
+            )}
           </Box>
         </React.Fragment>
       ))}

--- a/src/components/EntityScorecardsCard.tsx
+++ b/src/components/EntityScorecardsCard.tsx
@@ -55,7 +55,9 @@ export function EntityScorecardsCard({
 
   const scorecards = response.scorecards;
 
-  const flattenedChecks = scorecards.flatMap((scorecard) => scorecard.checks);
+  const flattenedChecks = scorecards.flatMap<ScorecardCheck>(
+    (scorecard) => scorecard.checks
+  );
 
   return (
     <InfoCard
@@ -142,27 +144,33 @@ function LevelsTab({ scorecards }: { scorecards: Scorecard[] }) {
               minWidth: 0,
             }}
           >
-            <Box sx={{ marginRight: 8 }}>
-              <LevelIcon
-                color={
-                  scorecard.current_level?.color ??
-                  scorecard.empty_level.color ??
-                  DEFAULT_NO_LEVEL_COLOR
-                }
-              />
-            </Box>
-            <Box
-              sx={{
-                overflow: "hidden",
-                textOverflow: "ellipsis",
-                minWidth: 0,
-                whiteSpace: "nowrap",
-              }}
-            >
-              {scorecard.current_level?.name ??
-                scorecard.empty_level.label ??
-                "No level"}
-            </Box>
+            {scorecard.type === "LEVEL" && (
+              <>
+                <Box sx={{ marginRight: 8 }}>
+                  <LevelIcon
+                    color={
+                      scorecard.current_level?.color ??
+                      scorecard.empty_level.color ??
+                      DEFAULT_NO_LEVEL_COLOR
+                    }
+                  />
+                </Box>
+                <Box
+                  sx={{
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    minWidth: 0,
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {scorecard.current_level?.name ??
+                    scorecard.empty_level.label ??
+                    "No level"}
+                </Box>
+              </>
+            )}
+
+            {scorecard.type === "POINTS" && <Box>TODO: PBS info</Box>}
           </Box>
         </React.Fragment>
       ))}

--- a/src/components/EntityScorecardsPage.tsx
+++ b/src/components/EntityScorecardsPage.tsx
@@ -14,7 +14,7 @@ import Grid from "@material-ui/core/Grid";
 import useAsync from "react-use/lib/useAsync";
 import { DateTime } from "luxon";
 
-import { dxApiRef, Scorecard } from "../api";
+import { dxApiRef, Scorecard, ScorecardCheck } from "../api";
 import { LevelIcon } from "./LevelIcon";
 import { COLORS, DEFAULT_NO_LEVEL_COLOR } from "../styles";
 import { CheckResultBadge } from "./CheckResultBadge";
@@ -170,153 +170,231 @@ function ScorecardSummary({
             gridGap: 8,
           }}
         >
-          <RadialProgressIndicator
-            passedChecks={passedChecks}
-            totalChecks={totalChecks}
-          />
-          <Box sx={{ fontSize: 13, color: COLORS.GRAY_500, marginRight: 8 }}>
-            {passedChecks} / {totalChecks} checks passing
-          </Box>
-          <Box
-            sx={{
-              display: "flex",
-              alignItems: "center",
-              fontSize: 13,
-              whiteSpace: "nowrap",
-              minWidth: 0,
-            }}
-          >
-            <Box sx={{ marginRight: 4 }}>
-              <LevelIcon
-                color={
-                  scorecard.current_level?.color ??
-                  scorecard.empty_level.color ??
-                  DEFAULT_NO_LEVEL_COLOR
-                }
+          {scorecard.type === "LEVEL" && (
+            <>
+              <RadialProgressIndicator
+                passedChecks={passedChecks}
+                totalChecks={totalChecks}
               />
-            </Box>
-            <Box sx={{ fontSize: 13 }}>
-              {scorecard.current_level?.name ??
-                scorecard.empty_level.label ??
-                "No level"}
-            </Box>
-          </Box>
+              <Box
+                sx={{ fontSize: 13, color: COLORS.GRAY_500, marginRight: 8 }}
+              >
+                {passedChecks} / {totalChecks} checks passing
+              </Box>
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  fontSize: 13,
+                  whiteSpace: "nowrap",
+                  minWidth: 0,
+                }}
+              >
+                <Box sx={{ marginRight: 4 }}>
+                  <LevelIcon
+                    color={
+                      scorecard.current_level?.color ??
+                      scorecard.empty_level.color ??
+                      DEFAULT_NO_LEVEL_COLOR
+                    }
+                  />
+                </Box>
+                <Box sx={{ fontSize: 13 }}>
+                  {scorecard.current_level?.name ??
+                    scorecard.empty_level.label ??
+                    "No level"}
+                </Box>
+              </Box>
+            </>
+          )}
+
+          {scorecard.type === "POINTS" && <div>TODO: PBS info</div>}
         </Box>
       </div>
 
       {isOpen && (
         <>
           <Box sx={{ borderTop: `1px solid ${COLORS.GRAY_200}` }}>
-            {scorecard.levels.map((level, levelIdx) => {
-              const levelChecks = scorecard.checks.filter(
-                (check) => check.level.id === level.id
-              );
+            {scorecard.type === "LEVEL" &&
+              scorecard.levels.map((level, levelIdx) => {
+                const checksInLevel = scorecard.checks.filter(
+                  (check) => check.level.id === level.id
+                );
 
-              return (
-                <Box key={level.id}>
-                  <Box
-                    sx={{
-                      height: 48,
-                      display: "flex",
-                      alignItems: "center",
-                      gridGap: 8,
-                      paddingLeft: 12,
-                      paddingRight: 12,
-                    }}
-                  >
+                return (
+                  <Box key={level.id}>
                     <Box
                       sx={{
+                        height: 48,
                         display: "flex",
                         alignItems: "center",
-                        justifyContent: "center",
+                        gridGap: 8,
+                        paddingLeft: 12,
+                        paddingRight: 12,
                       }}
                     >
-                      <LevelIcon color={level.color} />
-                    </Box>
-                    <Box sx={{ fontSize: 14, fontWeight: 700 }}>
-                      {level.name}
-                    </Box>
-                  </Box>
-                  <Box
-                    sx={{
-                      paddingLeft: 36,
-                      paddingRight: 12,
-                      paddingBottom: 8,
-                      borderBottom:
-                        levelIdx < scorecard.levels.length - 1
-                          ? `1px solid ${COLORS.GRAY_200}`
-                          : "none",
-                    }}
-                  >
-                    {levelChecks.map((check, checkIdx) => (
                       <Box
-                        key={check.id}
                         sx={{
                           display: "flex",
-                          flexDirection: "row",
                           alignItems: "center",
-                          gridGap: 8,
-                          padding: 8,
-                          borderBottom:
-                            checkIdx < levelChecks.length - 1
-                              ? `1px solid ${COLORS.GRAY_200}`
-                              : "none",
+                          justifyContent: "center",
                         }}
                       >
-                        <Box sx={{ flex: 1 }}>
-                          <Box sx={{ fontSize: 13, fontWeight: 500 }}>
-                            {check.name}
-                          </Box>
-                          <Box
-                            sx={{
-                              fontSize: 13,
-                              fontWeight: 400,
-                              color: "#7f7f7f",
-                            }}
-                          >
-                            {check.description}
-                          </Box>
-                        </Box>
-                        <Box>
-                          {check.executed_at && (
-                            <Box
-                              sx={{
-                                fontSize: 13,
-                                color: COLORS.GRAY_400,
-                                display: "flex",
-                                alignItems: "center",
-                                gridGap: 4,
-                              }}
-                            >
-                              <TimeIcon />
-                              <span>
-                                {DateTime.fromISO(check.executed_at, {
-                                  zone: "utc",
-                                }).toRelative()}
-                              </span>
-                            </Box>
-                          )}
-                        </Box>
-                        <Box>
-                          <CheckResultBadge
-                            status={check.status}
-                            isPublished={check.published}
-                            outputEnabled={!!check.output}
-                            outputValue={check.output?.value ?? null}
-                            outputType={check.output?.type ?? null}
-                          />
-                        </Box>
+                        <LevelIcon color={level.color} />
                       </Box>
-                    ))}
+                      <Box sx={{ fontSize: 14, fontWeight: 700 }}>
+                        {level.name}
+                      </Box>
+                    </Box>
+                    <Box
+                      sx={{
+                        paddingLeft: 36,
+                        paddingRight: 12,
+                        paddingBottom: 8,
+                        borderBottom:
+                          levelIdx < scorecard.levels.length - 1
+                            ? `1px solid ${COLORS.GRAY_200}`
+                            : "none",
+                      }}
+                    >
+                      {checksInLevel.map((check, checkIdx) => (
+                        <CheckSummary
+                          key={check.id}
+                          check={check}
+                          showBottomBorder={checkIdx < checksInLevel.length - 1}
+                        />
+                      ))}
+                    </Box>
                   </Box>
-                </Box>
-              );
-            })}
+                );
+              })}
+
+            {scorecard.type === "POINTS" &&
+              scorecard.groups.map((checkGroup, checkGroupIdx) => {
+                const checksInCheckGroup = scorecard.checks.filter(
+                  (check) => check.group.id === checkGroup.id
+                );
+
+                return (
+                  <Box key={checkGroup.id}>
+                    <Box
+                      sx={{
+                        height: 48,
+                        display: "flex",
+                        alignItems: "center",
+                        gridGap: 8,
+                        paddingLeft: 12,
+                        paddingRight: 12,
+                      }}
+                    >
+                      <Box
+                        sx={{
+                          display: "flex",
+                          alignItems: "center",
+                          justifyContent: "center",
+                        }}
+                      >
+                        TODO: something
+                      </Box>
+                      <Box sx={{ fontSize: 14, fontWeight: 700 }}>
+                        {checkGroup.name}
+                      </Box>
+                    </Box>
+                    <Box
+                      sx={{
+                        paddingLeft: 36,
+                        paddingRight: 12,
+                        paddingBottom: 8,
+                        borderBottom:
+                          checkGroupIdx < scorecard.groups.length - 1
+                            ? `1px solid ${COLORS.GRAY_200}`
+                            : "none",
+                      }}
+                    >
+                      {checksInCheckGroup.map((check, checkIdx) => (
+                        <CheckSummary
+                          key={check.id}
+                          check={check}
+                          showBottomBorder={
+                            checkIdx < checksInCheckGroup.length - 1
+                          }
+                        />
+                      ))}
+                    </Box>
+                  </Box>
+                );
+              })}
           </Box>
           <BottomLink link={entityScorecardUrl} title="View scorecard in DX" />
         </>
       )}
     </Card>
+  );
+}
+
+function CheckSummary({
+  check,
+  showBottomBorder,
+}: {
+  check: ScorecardCheck;
+  showBottomBorder: boolean;
+}) {
+  return (
+    <Box
+      key={check.id}
+      sx={{
+        display: "flex",
+        flexDirection: "row",
+        alignItems: "center",
+        gridGap: 8,
+        padding: 8,
+        borderBottom: showBottomBorder
+          ? `1px solid ${COLORS.GRAY_200}`
+          : "none",
+      }}
+    >
+      <Box sx={{ flex: 1 }}>
+        <Box sx={{ fontSize: 13, fontWeight: 500 }}>{check.name}</Box>
+        <Box
+          sx={{
+            fontSize: 13,
+            fontWeight: 400,
+            color: "#7f7f7f",
+          }}
+        >
+          {check.description}
+        </Box>
+      </Box>
+      <Box>
+        {check.executed_at && (
+          <Box
+            sx={{
+              fontSize: 13,
+              color: COLORS.GRAY_400,
+              display: "flex",
+              alignItems: "center",
+              gridGap: 4,
+            }}
+          >
+            <TimeIcon />
+            <span>
+              {DateTime.fromISO(check.executed_at, {
+                zone: "utc",
+              }).toRelative()}
+            </span>
+          </Box>
+        )}
+      </Box>
+      <Box>
+        <CheckResultBadge
+          status={check.status}
+          isPublished={check.published}
+          outputEnabled={!!check.output}
+          outputValue={check.output?.value ?? null}
+          outputType={check.output?.type ?? null}
+        />
+      </Box>
+    </Box>
   );
 }
 

--- a/src/components/EntityScorecardsPage.tsx
+++ b/src/components/EntityScorecardsPage.tsx
@@ -112,10 +112,6 @@ function ScorecardSummary({
   const entityIdentifier = entity.metadata.name;
   const entityScorecardUrl = `https://app.getdx.com/catalog/${entityIdentifier}/scorecards?expanded=${scorecard.id}`;
 
-  const totalChecks = scorecard.checks.length;
-  const passedChecks = scorecard.checks.filter(
-    (check) => check.passed === true
-  ).length;
   return (
     <Card key={scorecard.id}>
       <div
@@ -172,15 +168,6 @@ function ScorecardSummary({
         >
           {scorecard.type === "LEVEL" && (
             <>
-              <RadialProgressIndicator
-                passedChecks={passedChecks}
-                totalChecks={totalChecks}
-              />
-              <Box
-                sx={{ fontSize: 13, color: COLORS.GRAY_500, marginRight: 8 }}
-              >
-                {passedChecks} / {totalChecks} checks passing
-              </Box>
               <Box
                 sx={{
                   display: "flex",
@@ -208,7 +195,19 @@ function ScorecardSummary({
             </>
           )}
 
-          {scorecard.type === "POINTS" && <div>TODO: PBS info</div>}
+          {scorecard.type === "POINTS" && (
+            <>
+              <Box sx={{ fontSize: 13, color: COLORS.GRAY_500 }}>
+                {scorecard.points_meta.points_achieved} /{" "}
+                {scorecard.points_meta.points_total} points
+              </Box>
+
+              <RadialProgressIndicator
+                numerator={scorecard.points_meta.points_achieved}
+                denominator={scorecard.points_meta.points_total}
+              />
+            </>
+          )}
         </Box>
       </div>
 
@@ -270,9 +269,9 @@ function ScorecardSummary({
               })}
 
             {scorecard.type === "POINTS" &&
-              scorecard.groups.map((checkGroup, checkGroupIdx) => {
+              scorecard.check_groups.map((checkGroup, checkGroupIdx) => {
                 const checksInCheckGroup = scorecard.checks.filter(
-                  (check) => check.group.id === checkGroup.id
+                  (check) => check.check_group.id === checkGroup.id
                 );
 
                 return (
@@ -283,19 +282,10 @@ function ScorecardSummary({
                         display: "flex",
                         alignItems: "center",
                         gridGap: 8,
-                        paddingLeft: 12,
+                        paddingLeft: 42,
                         paddingRight: 12,
                       }}
                     >
-                      <Box
-                        sx={{
-                          display: "flex",
-                          alignItems: "center",
-                          justifyContent: "center",
-                        }}
-                      >
-                        TODO: something
-                      </Box>
                       <Box sx={{ fontSize: 14, fontWeight: 700 }}>
                         {checkGroup.name}
                       </Box>
@@ -306,7 +296,7 @@ function ScorecardSummary({
                         paddingRight: 12,
                         paddingBottom: 8,
                         borderBottom:
-                          checkGroupIdx < scorecard.groups.length - 1
+                          checkGroupIdx < scorecard.check_groups.length - 1
                             ? `1px solid ${COLORS.GRAY_200}`
                             : "none",
                       }}

--- a/src/components/RadialProgressIndicator.tsx
+++ b/src/components/RadialProgressIndicator.tsx
@@ -2,19 +2,19 @@ import React from "react";
 import { PieChart, Pie } from "recharts";
 
 export function RadialProgressIndicator({
-  passedChecks,
-  totalChecks,
+  numerator,
+  denominator,
 }: {
-  passedChecks: number;
-  totalChecks: number;
+  numerator: number;
+  denominator: number;
 }) {
-  const isComplete = passedChecks === totalChecks;
-  const isBlank = totalChecks === 0;
+  const isComplete = numerator === denominator;
+  const isBlank = denominator === 0;
 
   return (
     <div
       role="progressbar"
-      aria-label={`Progress: ${passedChecks} of ${totalChecks} checks passing`}
+      aria-label={`Progress: ${numerator} of ${denominator}`}
     >
       {isBlank && (
         <svg
@@ -77,12 +77,12 @@ export function RadialProgressIndicator({
             data={[
               {
                 name: "Passed",
-                value: Math.round(passedChecks),
+                value: Math.round(numerator),
                 fill: "url(#pieGradient)",
               },
               {
                 name: "Failed",
-                value: Math.round(totalChecks - passedChecks),
+                value: Math.round(denominator - numerator),
                 fill: "#E5E7EB", // gray-200 for the background
               },
             ]}


### PR DESCRIPTION
## Overview

This adds support for scorecard types of `LEVEL` and `POINTS`.

Changed components:

- `EntityScorecardsCard`
  - For Points-based scorecards: shows a radial progress indicator and points achieved out of points total
- `EntityScorecardsPage`
  - For Level-based scorecards: no longer shows checks passing progression
  - For Points-based scorecards: shows a radial progress indicator and points achieved out of points total

## Screenshots

### Overview page

<img width="418" alt="image" src="https://github.com/user-attachments/assets/f234fc04-2e23-4205-80f6-6368728a8177" />

### Scorecards page

<img width="1253" alt="image" src="https://github.com/user-attachments/assets/1e70af01-2167-4c9b-83b3-2f46de65fe39" />
