### PR TITLE
Add support for custom output options

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -74,19 +74,7 @@ export type ScorecardCheck =
   | LevelBasedScorecardCheck
   | PointsBasedScorecardCheck;
 
-export type PointsBasedScorecardCheck = {
-  id: string;
-  name: string;
-  description: string;
-  published: boolean;
-  output: {
-    type: OutputType;
-    value: string | number | null;
-  } | null;
-  passed: boolean;
-  status: "PASS" | "FAIL" | "WARN";
-  executed_at: string | null;
-
+export type PointsBasedScorecardCheck = CheckCommon & {
   points: number;
   check_group: {
     id: string;
@@ -94,23 +82,28 @@ export type PointsBasedScorecardCheck = {
   };
 };
 
-export type LevelBasedScorecardCheck = {
-  id: string;
-  name: string;
-  description: string;
-  published: boolean;
-  output: {
-    type: OutputType;
-    value: string | number | null;
-  } | null;
-  passed: boolean;
-  status: "PASS" | "FAIL" | "WARN";
-  executed_at: string | null;
-
+export type LevelBasedScorecardCheck = CheckCommon & {
   level: {
     id: string;
     name: string;
   };
+};
+
+type CheckCommon = {
+  id: string;
+  name: string;
+  description: string;
+  published: boolean;
+  output: Output | null;
+  passed: boolean;
+  status: "PASS" | "FAIL" | "WARN";
+  executed_at: string | null;
+};
+
+export type Output = {
+  type: OutputType;
+  value: string | number | null;
+  custom_options?: CustomOutputOptions;
 };
 
 export type OutputType =
@@ -121,7 +114,13 @@ export type OutputType =
   | "duration_seconds"
   | "duration_minutes"
   | "duration_hours"
-  | "duration_days";
+  | "duration_days"
+  | "custom";
+
+export type CustomOutputOptions = {
+  unit: "string";
+  decimals: "auto" | number;
+};
 
 export type TasksResponse = {
   ok: true;

--- a/src/components/EntityScorecardsCard.tsx
+++ b/src/components/EntityScorecardsCard.tsx
@@ -240,6 +240,7 @@ function ChecksTab({ checks }: { checks: ScorecardCheck[] }) {
               outputEnabled={check.output !== null}
               outputValue={check.output?.value ?? null}
               outputType={check.output?.type ?? null}
+              outputCustomOptions={check.output?.custom_options}
             />
           </Box>
         </React.Fragment>

--- a/src/components/EntityScorecardsCard.tsx
+++ b/src/components/EntityScorecardsCard.tsx
@@ -28,7 +28,7 @@ export function EntityScorecardsCard({
 
   const entityIdentifier = entity.metadata.name;
 
-  const [tab, setTab] = useState<"levels" | "checks">("levels");
+  const [tab, setTab] = useState<"overview" | "checks">("overview");
 
   const {
     value: response,
@@ -77,7 +77,7 @@ export function EntityScorecardsCard({
             onChange={(_, value) => setTab(value)}
             indicatorColor="primary"
           >
-            <Tab value="levels" label="Levels" />
+            <Tab value="overview" label="Overview" />
             <Tab value="checks" label="Checks" />
           </Tabs>
         </Box>
@@ -90,7 +90,7 @@ export function EntityScorecardsCard({
       noPadding
     >
       <Box sx={{ maxHeight: contentMaxHeight, overflow: "auto", padding: 16 }}>
-        {tab === "levels" && <LevelsTab scorecards={scorecards} />}
+        {tab === "overview" && <OverviewTab scorecards={scorecards} />}
 
         {tab === "checks" && <ChecksTab checks={flattenedChecks} />}
       </Box>
@@ -98,7 +98,7 @@ export function EntityScorecardsCard({
   );
 }
 
-function LevelsTab({ scorecards }: { scorecards: Scorecard[] }) {
+function OverviewTab({ scorecards }: { scorecards: Scorecard[] }) {
   if (scorecards.length === 0) {
     return (
       <Box


### PR DESCRIPTION
This adds support for the `custom` output type and its options.

As a bonus change, the `EntityScorecardsCard` main tab is now called `Overview` instead of `Levels`, to better accommodate points-based scorecards.