### PR TITLE
TEMP: entity identifier prop

### DIFF
--- a/src/components/EntityScorecardsCard.tsx
+++ b/src/components/EntityScorecardsCard.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 import { InfoCard } from "@backstage/core-components";
-import { useEntity } from "@backstage/plugin-catalog-react";
 import useAsync from "react-use/lib/useAsync";
 import { useApi } from "@backstage/core-plugin-api";
 import { Progress, ResponseErrorPanel } from "@backstage/core-components";
@@ -17,16 +16,14 @@ import { RadialProgressIndicator } from "./RadialProgressIndicator";
 
 type EntityScorecardsCardProps = {
   contentMaxHeight?: string | number;
+  entityIdentifier: string;
 };
 
 export function EntityScorecardsCard({
   contentMaxHeight = "30rem",
+  entityIdentifier,
 }: EntityScorecardsCardProps) {
   const dxApi = useApi(dxApiRef);
-
-  const { entity } = useEntity();
-
-  const entityIdentifier = entity.metadata.name;
 
   const [tab, setTab] = useState<"overview" | "checks">("overview");
 


### PR DESCRIPTION
Temporary version for troubleshooting purposes only! This removes the use of `useEntity` and instead lets the caller pass in an `entityIdentifier` prop.