### PR TITLE
Add entityIdentifier prop to all scorecards components

### DIFF
--- a/src/components/EntityScorecardsCard.tsx
+++ b/src/components/EntityScorecardsCard.tsx
@@ -15,13 +15,13 @@ import { LevelIcon } from "./LevelIcon";
 import { RadialProgressIndicator } from "./RadialProgressIndicator";
 
 type EntityScorecardsCardProps = {
-  contentMaxHeight?: string | number;
   entityIdentifier: string;
+  contentMaxHeight?: string | number;
 };
 
 export function EntityScorecardsCard({
-  contentMaxHeight = "30rem",
   entityIdentifier,
+  contentMaxHeight = "30rem",
 }: EntityScorecardsCardProps) {
   const dxApi = useApi(dxApiRef);
 

--- a/src/components/EntityScorecardsPage.tsx
+++ b/src/components/EntityScorecardsPage.tsx
@@ -7,7 +7,6 @@ import {
   BottomLink,
 } from "@backstage/core-components";
 import { useApi } from "@backstage/core-plugin-api";
-import { useEntity } from "@backstage/plugin-catalog-react";
 import Box from "@material-ui/core/Box";
 import Card from "@material-ui/core/Card";
 import Grid from "@material-ui/core/Grid";
@@ -21,12 +20,14 @@ import { CheckResultBadge } from "./CheckResultBadge";
 import { RadialProgressIndicator } from "./RadialProgressIndicator";
 import { PoweredByDX } from "./Branding";
 
-export function EntityScorecardsPage() {
+type EntityScorecardsPageProps = {
+  entityIdentifier: string;
+};
+
+export function EntityScorecardsPage({
+  entityIdentifier,
+}: EntityScorecardsPageProps) {
   const dxApi = useApi(dxApiRef);
-
-  const { entity } = useEntity();
-
-  const entityIdentifier = entity.metadata.name;
 
   const {
     value: response,
@@ -87,6 +88,7 @@ export function EntityScorecardsPage() {
           <Grid item xs={12} key={scorecard.id}>
             <ScorecardSummary
               scorecard={scorecard}
+              entityIdentifier={entityIdentifier}
               isOpen={expandedScorecardId === scorecard.id}
               onOpenChange={(isOpen) => {
                 setExpandedScorecardId(isOpen ? scorecard.id : null);
@@ -101,15 +103,15 @@ export function EntityScorecardsPage() {
 
 function ScorecardSummary({
   scorecard,
+  entityIdentifier,
   isOpen,
   onOpenChange,
 }: {
   scorecard: Scorecard;
+  entityIdentifier: string;
   isOpen: boolean;
   onOpenChange: (isOpen: boolean) => void;
 }) {
-  const { entity } = useEntity();
-  const entityIdentifier = entity.metadata.name;
   const entityScorecardUrl = `https://app.getdx.com/catalog/${entityIdentifier}/scorecards?expanded=${scorecard.id}`;
 
   return (

--- a/src/components/EntityTasksCard.tsx
+++ b/src/components/EntityTasksCard.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { InfoCard } from "@backstage/core-components";
-import { useEntity } from "@backstage/plugin-catalog-react";
 import useAsync from "react-use/lib/useAsync";
 import { useApi } from "@backstage/core-plugin-api";
 import { Progress, ResponseErrorPanel } from "@backstage/core-components";
@@ -13,17 +12,15 @@ import { dxApiRef, Task } from "../api";
 import { COLORS, TASK_PRIORITY_COLORS } from "../styles";
 
 type EntityTasksCardProps = {
+  entityIdentifier: string;
   contentMaxHeight?: string | number;
 };
 
 export function EntityTasksCard({
+  entityIdentifier,
   contentMaxHeight = "30rem",
 }: EntityTasksCardProps) {
   const dxApi = useApi(dxApiRef);
-
-  const { entity } = useEntity();
-
-  const entityIdentifier = entity.metadata.name;
 
   const {
     value: response,

--- a/src/components/EntityTasksPage.tsx
+++ b/src/components/EntityTasksPage.tsx
@@ -7,7 +7,6 @@ import {
   BottomLink,
 } from "@backstage/core-components";
 import { useApi } from "@backstage/core-plugin-api";
-import { useEntity } from "@backstage/plugin-catalog-react";
 import Box from "@material-ui/core/Box";
 import IconButton from "@material-ui/core/IconButton";
 import Card from "@material-ui/core/Card";
@@ -22,12 +21,12 @@ import { dxApiRef, Task, User } from "../api";
 import { COLORS, TASK_PRIORITY_COLORS } from "../styles";
 import { PoweredByDX } from "./Branding";
 
-export function EntityTasksPage() {
+type EntityTasksPageProps = {
+  entityIdentifier: string;
+};
+
+export function EntityTasksPage({ entityIdentifier }: EntityTasksPageProps) {
   const dxApi = useApi(dxApiRef);
-
-  const { entity } = useEntity();
-
-  const entityIdentifier = entity.metadata.name;
 
   const {
     value: response,
@@ -94,6 +93,7 @@ export function EntityTasksPage() {
               tasks={tasks.filter(
                 (task) => task.initiative.priority === priorityLevel
               )}
+              entityIdentifier={entityIdentifier}
             />
           </Grid>
         ))}
@@ -105,12 +105,12 @@ export function EntityTasksPage() {
 function PriorityTaskList({
   priorityLevel,
   tasks,
+  entityIdentifier,
 }: {
   priorityLevel: number;
   tasks: Task[];
+  entityIdentifier: string;
 }) {
-  const { entity } = useEntity();
-  const entityIdentifier = entity.metadata.name;
   const entityTasksUrl = `https://app.getdx.com/catalog/${entityIdentifier}/tasks`;
 
   if (tasks.length === 0) {
@@ -150,7 +150,7 @@ function PriorityTaskList({
               borderTop: idx === 0 ? "none" : `1px solid ${COLORS.GRAY_200}`,
             }}
           >
-            <TaskSummary task={task} />
+            <TaskSummary task={task} entityIdentifier={entityIdentifier} />
           </Box>
         ))}
       </Box>
@@ -174,9 +174,13 @@ function PriorityIndicator({ priorityLevel }: { priorityLevel: number }) {
   );
 }
 
-function TaskSummary({ task }: { task: Task }) {
-  const { entity } = useEntity();
-  const entityIdentifier = entity.metadata.name;
+function TaskSummary({
+  task,
+  entityIdentifier,
+}: {
+  task: Task;
+  entityIdentifier: string;
+}) {
   const entityTasksUrl = `https://app.getdx.com/catalog/${entityIdentifier}/tasks`;
 
   const [checkDescriptionExpanded, setCheckDescriptionExpanded] =


### PR DESCRIPTION
This adds `entityIdentifier` as a prop on all the scorecards-related components. This makes it possible to add the components on pages that do not include the entity context.