### PR TITLE
Convert page-level components to be ComponentExtension

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -171,21 +171,23 @@ export const EntityTasksCard = dxPlugin.provide(
 );
 
 export const EntityScorecardsPage = dxPlugin.provide(
-  createRoutableExtension({
+  createComponentExtension({
     name: "EntityScorecardsPage",
-    component: () =>
-      import("./components/EntityScorecardsPage").then(
-        (m) => m.EntityScorecardsPage,
-      ),
-    mountPoint: rootRouteRef,
+    component: {
+      lazy: () =>
+        import("./components/EntityScorecardsPage").then(
+          (m) => m.EntityScorecardsPage,
+        ),
+    },
   }),
 );
 
 export const EntityTasksPage = dxPlugin.provide(
-  createRoutableExtension({
+  createComponentExtension({
     name: "EntityTasksPage",
-    component: () =>
-      import("./components/EntityTasksPage").then((m) => m.EntityTasksPage),
-    mountPoint: rootRouteRef,
+    component: {
+      lazy: () =>
+        import("./components/EntityTasksPage").then((m) => m.EntityTasksPage),
+    },
   }),
 );


### PR DESCRIPTION
This converts our two page-level components, `EntityScorecardsPage` and `EntityScorecardsPage`, to call `createComponentExtension` instead of `createRoutableExtension`. We were not taking advantage of the router discovery features, and it was causing problems with our wrapper strategy, so we are migrating off of it.