### PR TITLE
Update README.md with additional import

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ First, in `packages/app/src/components/catalog/EntityPage.tsx`, define wrapper c
 
 ```tsx
 import { EntityScorecardsCard } from "@get-dx/backstage-plugin";
+import { useEntity } from '@backstage/plugin-catalog-react';
 
 function EntityScorecardsCardWrapped() {
   const { entity } = useEntity();


### PR DESCRIPTION
The readme.md file  is missing 
When integration the DX plugin to Backstage with latest version  needed to add 
import { useEntity } from '@backstage/plugin-catalog-react';
