### PR TITLE
Add datafeedTokens config option to support secret manager integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- Fix an infinite loop on `DxDataChardCard` if `variables` prop is not present.
+### Added
+
+- Added optional `datafeedTokens` configuration that allows datafeed tokens to be referenced by name in `DxDataChartCard` components. This enables tokens to be stored in secret managers and referenced securely instead of hardcoding them directly in the code.
+
+### Fixed
+
+- Fix an infinite loop on `DxDataChartCard` if `variables` prop is not present.
 
 ## 1.0.0 - 2025-07-10
 

--- a/config.d.ts
+++ b/config.d.ts
@@ -9,5 +9,21 @@ export interface Config {
      * @visibility frontend
      */
     appId?: string;
+    
+    /**
+     * Optional datafeed tokens that can be referenced by name in DxDataChartCard components.
+     * This allows tokens to be stored in secret managers and referenced securely
+     * instead of hardcoding them directly in the code.
+     *
+     * Example:
+     *   datafeedTokens:
+     *     deploymentFrequency: ${DEPLOYMENT_FREQUENCY_TOKEN}
+     *     changeFailRate: ${CHANGE_FAIL_RATE_TOKEN}
+     *
+     * @visibility frontend
+     */
+    datafeedTokens?: {
+      [tokenName: string]: string;
+    };
   };
 }

--- a/config.d.ts
+++ b/config.d.ts
@@ -20,7 +20,7 @@ export interface Config {
      *     deploymentFrequency: ${DEPLOYMENT_FREQUENCY_TOKEN}
      *     changeFailRate: ${CHANGE_FAIL_RATE_TOKEN}
      *
-     * @visibility frontend
+     * @deepVisibility frontend
      */
     datafeedTokens?: {
       [tokenName: string]: string;

--- a/config.d.ts
+++ b/config.d.ts
@@ -9,7 +9,7 @@ export interface Config {
      * @visibility frontend
      */
     appId?: string;
-    
+
     /**
      * Optional datafeed tokens that can be referenced by name in DxDataChartCard components.
      * This allows tokens to be stored in secret managers and referenced securely


### PR DESCRIPTION
This PR adds a `dx.datafeedTokens` configuration option to the plugin, allowing users to define datafeed tokens in their `app-config.yaml` that can be pulled from secret managers or environment variables instead of hardcoding them directly in the code.

## Changes
- Added `datafeedTokens` map to the DX configuration in `config.d.ts`
- Users can now define named tokens in their config:
  ```yaml
  dx:
    datafeedTokens:
      deploymentFrequency: ${DEPLOYMENT_FREQUENCY_TOKEN}
      changeFailRate: ${CHANGE_FAIL_RATE_TOKEN}
  ```

## Benefits
- Improved security by supporting secret manager integration
- Better separation of concerns between configuration and code
- Easier token rotation and management