### PR TITLE
Bugfix on DxDataChartCard: infinite loop when query variables are not present

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -1,4 +1,4 @@
-name: CI Checks
+name: checks
 
 on:
   push:

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -1,4 +1,4 @@
-name: checks
+name: CI Checks
 
 on:
   push:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fix an infinite loop on `DxDataChardCard` if `variables` prop is not present.
+
 ## 1.0.0 - 2025-07-10
 
 ### Added
 
-- This adds a new `DxDataChart` component that can be used to display data from DX data studio queries!
+- This adds a new `DxDataChartCard` component that can be used to display data from DX data studio queries!
 
 ### Breaking changes
 
-- This version removes the following components which are made redundant by the `DxDataChart` flexibility.
+- This version removes the following components which are made redundant by the `DxDataChartCard` flexibility.
 
   - `EntityChangeFailureRateCard`
   - `EntityDeploymentFrequencyCard`

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The `DxDataChartCard` component displays custom metrics from DX datafeed endpoin
 
 - `title`: Card title
 - `description`: Optional card description/subtitle
-- `datafeedToken`: Token for the DX datafeed endpoint
+- `datafeedToken`: Token for the DX datafeed endpoint - see [datafeed docs](https://docs.getdx.com/data-studio/#datafeeds)
 - `unit`: Unit label for the chart data (e.g., "deployments", "issues", "mins")
 - `variables`: Optional variables to pass to the datafeed endpoint
 - `chartConfig`: Configuration object specifying:

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ These components visualize Scorecards and Tasks for an entity.
 
 > The Service Cloud components require an `entityIdentifier` prop, in order to fetch the correct DX entity. If you use the Backstage catalog plugin, you can call Backstage's `useEntity` hook to get metadata to help map or construct the DX entity identifier.
 
+
 ### Custom Data Charts
 
 | Component             | Description                                                                      |

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ These components visualize Scorecards and Tasks for an entity.
 
 > The Service Cloud components require an `entityIdentifier` prop, in order to fetch the correct DX entity. If you use the Backstage catalog plugin, you can call Backstage's `useEntity` hook to get metadata to help map or construct the DX entity identifier.
 
-
 ### Custom Data Charts
 
 | Component             | Description                                                                      |

--- a/src/components/DxDataChartCard.tsx
+++ b/src/components/DxDataChartCard.tsx
@@ -10,6 +10,8 @@ import { LineChart } from "./LineChart";
 import { dxApiRef } from "../api";
 import { Table, TableColumn } from "@backstage/core-components";
 
+const STABLE_EMPTY_OBJECT = Object.freeze({});
+
 export interface DxDataChartCardProps {
   title: string;
   description?: string;
@@ -27,7 +29,7 @@ export function DxDataChartCard({
   datafeedToken,
   title,
   description,
-  variables = {},
+  variables = STABLE_EMPTY_OBJECT,
   chartConfig,
   unit,
 }: DxDataChartCardProps) {


### PR DESCRIPTION
This fixes an issue where DxDataChartCard would get stuck in an infinite loop if the `variables` prop was not specified. This was because `variables` would default to an empty object `{}`, but the reference was not stable, causing the `useAsync` hook to re-trigger in an infinite loop.