### PR TITLE
fix: forward output.custom_options to CheckResultBadge in page and drawer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- `EntityScorecardsPage` no longer throws `"Output custom options are required for custom output type"` when rendering checks whose `output.type === "custom"`. Both `EntityScorecardsPage` and `CheckResultDrawer` now forward `output.custom_options` to `CheckResultBadge`, matching `EntityScorecardsCard`.
+
 ## 1.1.1 - 2026-01-29
 
 ### Docs

--- a/src/components/CheckResultDrawer.tsx
+++ b/src/components/CheckResultDrawer.tsx
@@ -67,6 +67,7 @@ export function CheckResultDrawer({
               outputEnabled={!!check.output}
               outputValue={check.output?.value ?? null}
               outputType={check.output?.type ?? null}
+              outputCustomOptions={check.output?.custom_options}
             />
             {check.executed_at && (
               <Box

--- a/src/components/EntityScorecardsPage.tsx
+++ b/src/components/EntityScorecardsPage.tsx
@@ -421,6 +421,7 @@ function CheckSummary({
           outputEnabled={!!check.output}
           outputValue={check.output?.value ?? null}
           outputType={check.output?.type ?? null}
+          outputCustomOptions={check.output?.custom_options}
         />
       </div>
       <CheckResultDrawer


### PR DESCRIPTION
## Summary

Fixes `CheckResultBadge` throwing `"Output custom options are required for custom output type"` for every check whose result has `output.type === "custom"`.

`EntityScorecardsCard` already forwards `output.custom_options` to `CheckResultBadge` (`src/components/EntityScorecardsCard.tsx:291`). Two other callers were missing that prop:

- `EntityScorecardsPage` — `src/components/EntityScorecardsPage.tsx:423` — throws on initial render of the scorecards tab; every custom-output check surfaces as an `ErrorBoundary` tile.
- `CheckResultDrawer` — `src/components/CheckResultDrawer.tsx:69` — throws when a user clicks a check to open the detail drawer, even if the page renders.

When `CheckResultBadge` reaches the `case "custom"` branch in `formatSqlOutputValue` (`src/components/CheckResultBadge.tsx`), it hits:

```ts
if (!outputCustomOptions) {
  throw new Error(
    "Output custom options are required for custom output type"
  );
}
```

## Reproduction

1. Configure a scorecard with at least one check that has `output_enabled = true`, `output_type = "custom"`, and `output_custom_options = { unit = "...", decimals = 0 }`.
2. Run the check so the per-entity results API returns `output: { value: <num>, type: "custom", custom_options: {...} }`.
3. Render `<EntityScorecardsPage entityIdentifier="..." />` — error tiles appear.
4. With the page-only fix, click one of the affected checks — the drawer then errors for the same reason.

`EntityScorecardsCard` on the same entity renders correctly — only the full-page component and the drawer are affected.

## Fix

Forward `output.custom_options` to `CheckResultBadge` from both `EntityScorecardsPage` and `CheckResultDrawer`, matching how `EntityScorecardsCard` already passes it.

```diff
           outputValue={check.output?.value ?? null}
           outputType={check.output?.type ?? null}
+          outputCustomOptions={check.output?.custom_options}
         />
```

## Changes

- `src/components/EntityScorecardsPage.tsx` — pass `outputCustomOptions` to `CheckResultBadge`.
- `src/components/CheckResultDrawer.tsx` — pass `outputCustomOptions` to `CheckResultBadge`.
- `CHANGELOG.md` — Unreleased / Fixed entry.

## Test plan

- [ ] Scorecard with a custom-output check: page renders the formatted value (e.g. `2 SLOs`) instead of erroring.
- [ ] Clicking through to the check detail drawer: drawer renders without errors.
- [ ] Scorecard with non-custom outputs (`number`, `percent`, `duration_*`, `currency_usd`): unchanged.
- [ ] Check with `output_enabled = false`: unchanged (no output rendered).
- [ ] `EntityScorecardsCard` behaviour unchanged (it already passed this prop).