### PR TITLE
Bump version to 1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 1.1.2 - 2026-06-22
+
 ### Fixed
 
-- `EntityScorecardsPage` no longer throws `"Output custom options are required for custom output type"` when rendering checks whose `output.type === "custom"`. Both `EntityScorecardsPage` and `CheckResultDrawer` now forward `output.custom_options` to `CheckResultBadge`, matching `EntityScorecardsCard`.
+- `EntityScorecardsPage` no longer throws `"Output custom options are required for custom output type"` when rendering checks whose `output.type === "custom"`. Both `EntityScorecardsPage` and `CheckResultDrawer` now forward `output.custom_options` to `CheckResultBadge`, matching `EntityScorecardsCard`. (Thank you to @colmcahalane-toast!)
 
 ## 1.1.1 - 2026-01-29
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@get-dx/backstage-plugin",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Backstage plugin for DX! https://getdx.com",
   "main": "dist/index.esm.js",
   "module": "dist/index.esm.js",


### PR DESCRIPTION
This bumps the plugin version to `1.1.2`, to publish the fix from https://github.com/get-dx/backstage-plugin/pull/54.



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

