### PR TITLE
Fix publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,6 +8,8 @@ jobs:
     name: publish-npm
     runs-on: ubuntu-latest
     environment: Publish
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@main
@@ -23,5 +25,3 @@ jobs:
       - run: yarn build
 
       - run: yarn publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,13 +12,14 @@ jobs:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@main
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           registry-url: "https://registry.npmjs.org"
+          cache: "yarn"
 
       - run: yarn --frozen-lockfile
       - run: yarn tsc


### PR DESCRIPTION
This fixes up our `publish` GHA workflow:

- Pins the `checkout` and `setup-node` actions to specific major versions
  - Publish recently failed and I believe it's because of breaking changes to `setup-node` since our last publish, ~6mo ago
- Moves the `env` block up to apply to all steps






<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

