### PR TITLE
Setup NPM trusted publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -37,4 +37,4 @@ jobs:
         run: yarn build
 
       - name: Publish to npm
-        run: npm publish --provenance
+        run: npm publish --provenance --access public

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,8 +1,14 @@
 name: Publish Package
+
 on:
   push:
     branches:
       - main
+
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   npm-publish:
     name: publish-npm
@@ -18,11 +24,17 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 20
-          registry-url: "https://registry.npmjs.org"
-          cache: "yarn"
+          registry-url: https://registry.npmjs.org
+          cache: yarn
 
-      - run: yarn --frozen-lockfile
-      - run: yarn tsc
-      - run: yarn build
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
 
-      - run: yarn publish
+      - name: Typecheck
+        run: yarn tsc
+
+      - name: Build package
+        run: yarn build
+
+      - name: Publish to npm
+        run: npm publish --provenance


### PR DESCRIPTION
This changes our `publish` workflow configuration so we can use [NPM trusted publishing](https://docs.npmjs.com/trusted-publishers). I've already made the config changes on the NPM side, so once this merges, the publish should happen.






<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev is reviewing this pull request…</strong>
Refresh the page in a few minutes to see the results.
<!-- /Rovo Dev code review status -->

