### PR TITLE
Remove env var from CI workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,8 +14,6 @@ jobs:
     name: publish-npm
     runs-on: ubuntu-latest
     environment: Publish
-    env:
-      NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
This removes the `NODE_AUTH_TOKEN` env var from the publish workflow, so we can fully use [Trusted Publishing](https://docs.npmjs.com/trusted-publishers) and not accidentally fall back to token-based auth.



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

