### PR TITLE
Upgrade node version in publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -16,14 +16,14 @@ jobs:
     environment: Publish
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v5
 
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org
-          cache: yarn
+          package-manager-cache: false
 
       - name: Install dependencies
         run: yarn --frozen-lockfile
@@ -35,4 +35,4 @@ jobs:
         run: yarn build
 
       - name: Publish to npm
-        run: npm publish --provenance --access public
+        run: npm publish

--- a/package.json
+++ b/package.json
@@ -3,10 +3,11 @@
   "version": "1.1.2",
   "description": "Backstage plugin for DX! https://getdx.com",
   "main": "dist/index.esm.js",
-  "module": "dist/index.esm.js",
+  "module": "./dist/index.esm.js",
   "types": "dist/index.d.ts",
   "repository": {
     "type": "git",
+    "url": "https://github.com/get-dx/backstage-plugin.git",
     "directory": "."
   },
   "author": "DX <developers@getdx.com>",


### PR DESCRIPTION
This upgrades the node version from 20 to 24 in the publish workflow, so [trusted publishing](https://docs.npmjs.com/trusted-publishers) dependencies will be present.



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

