### PR TITLE
fix(scorecards): correct check output units and related properties

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -81,7 +81,7 @@ type CheckCommon = {
   published: boolean;
   output: Output | null;
   message: string | null;
-  related_property: string | null;
+  related_properties: string[] | null;
   passed: boolean;
   status: "PASS" | "FAIL" | "WARN";
   executed_at: string | null;
@@ -105,7 +105,7 @@ export type OutputType =
   | "custom";
 
 export type CustomOutputOptions = {
-  unit: "string";
+  unit: string;
   decimals: "auto" | number;
 };
 

--- a/src/components/CheckResultBadge.test.tsx
+++ b/src/components/CheckResultBadge.test.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { CheckResultBadge, CheckResultBadgeProps } from "./CheckResultBadge";
+
+function renderBadge(props: Partial<CheckResultBadgeProps> = {}) {
+  return render(
+    <CheckResultBadge
+      status="PASS"
+      isPublished
+      outputEnabled
+      outputValue={null}
+      outputType={null}
+      {...props}
+    />
+  );
+}
+
+describe("CheckResultBadge", () => {
+  it("renders a custom unit verbatim rather than pluralizing it", () => {
+    renderBadge({
+      outputValue: 4,
+      outputType: "custom",
+      outputCustomOptions: { unit: "trace metrics", decimals: 0 },
+    });
+
+    expect(screen.getByText("4 trace metrics")).toBeInTheDocument();
+  });
+
+  it("renders a custom unit verbatim when decimals are automatic", () => {
+    renderBadge({
+      outputValue: 89,
+      outputType: "custom",
+      outputCustomOptions: { unit: "chars", decimals: "auto" },
+    });
+
+    expect(screen.getByText("89 chars")).toBeInTheDocument();
+  });
+
+  it("formats a custom value to the requested number of decimals", () => {
+    renderBadge({
+      outputValue: 0,
+      outputType: "custom",
+      outputCustomOptions: { unit: "% time > 90% util", decimals: 2 },
+    });
+
+    expect(screen.getByText("0.00 % time > 90% util")).toBeInTheDocument();
+  });
+
+  it("pluralizes built-in duration units", () => {
+    renderBadge({ outputValue: 3, outputType: "duration_days" });
+
+    expect(screen.getByText("3 days")).toBeInTheDocument();
+  });
+
+  it("keeps built-in duration units singular for a count of one", () => {
+    renderBadge({ outputValue: 1, outputType: "duration_days" });
+
+    expect(screen.getByText("1 day")).toBeInTheDocument();
+  });
+
+  it("falls back to the status text when output is disabled", () => {
+    renderBadge({
+      status: "FAIL",
+      outputEnabled: false,
+      outputValue: 4,
+      outputType: "number",
+    });
+
+    expect(screen.getByText("Not passed")).toBeInTheDocument();
+  });
+
+  it("shows a no-data placeholder when output is enabled but empty", () => {
+    renderBadge({ outputType: "number" });
+
+    expect(screen.getByText("(No data)")).toBeInTheDocument();
+  });
+});

--- a/src/components/CheckResultBadge.tsx
+++ b/src/components/CheckResultBadge.tsx
@@ -230,13 +230,15 @@ function formatCustomOutputValue(
   outputValue: number,
   outputCustomOptions: CustomOutputOptions
 ): string {
+  // The unit is author-supplied and already in its intended form, so it is
+  // rendered verbatim rather than pluralized.
   if (outputCustomOptions.decimals === "auto") {
-    return `${outputValue} ${pluralize(outputCustomOptions.unit, outputValue)}`;
+    return `${outputValue} ${outputCustomOptions.unit}`;
   }
 
   const valueWithDecimals = outputValue.toFixed(outputCustomOptions.decimals);
 
-  return `${valueWithDecimals} ${pluralize(outputCustomOptions.unit, outputValue)}`;
+  return `${valueWithDecimals} ${outputCustomOptions.unit}`;
 }
 
 function pluralize(text: string, count: number | null = null) {

--- a/src/components/CheckResultDrawer.test.tsx
+++ b/src/components/CheckResultDrawer.test.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { CheckResultDrawer } from "./CheckResultDrawer";
+import { LevelBasedScorecardCheck } from "../api";
+
+const check: LevelBasedScorecardCheck = {
+  id: "rcw3pkmrxp8j",
+  name: "Internal dependencies",
+  description: "Set the internal-dependency-documentation DX property.",
+  published: true,
+  output: { type: "string", value: "Needs doc link" },
+  message: null,
+  related_properties: null,
+  passed: false,
+  status: "FAIL",
+  executed_at: null,
+  level: { id: "92ktdhy45tls", name: "Required" },
+};
+
+function renderDrawer({
+  onEditRelatedProperty = () => {},
+  ...overrides
+}: Partial<LevelBasedScorecardCheck> & {
+  onEditRelatedProperty?: () => void;
+} = {}) {
+  return render(
+    <CheckResultDrawer
+      check={{ ...check, ...overrides }}
+      open
+      onClose={() => {}}
+      onEditRelatedProperty={onEditRelatedProperty}
+    />
+  );
+}
+
+describe("CheckResultDrawer", () => {
+  it("lists a single related property", () => {
+    renderDrawer({
+      related_properties: ["internal-dependency-documentation"],
+    });
+
+    expect(screen.getByText("Related property:")).toBeInTheDocument();
+    expect(
+      screen.getByText("internal-dependency-documentation")
+    ).toBeInTheDocument();
+  });
+
+  it("lists every related property when a check has several", () => {
+    renderDrawer({
+      related_properties: ["scaling-thresholds", "task-count"],
+    });
+
+    expect(screen.getByText("Related properties:")).toBeInTheDocument();
+    expect(screen.getByText("scaling-thresholds")).toBeInTheDocument();
+    expect(screen.getByText("task-count")).toBeInTheDocument();
+  });
+
+  it("offers an edit affordance for the related properties", async () => {
+    const onEditRelatedProperty = jest.fn();
+    renderDrawer({
+      related_properties: ["internal-dependency-documentation"],
+      onEditRelatedProperty,
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "Edit in DX" }));
+
+    expect(onEditRelatedProperty).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ["null", null],
+    ["empty", []],
+  ])("omits the related property section when %s", (_label, related) => {
+    renderDrawer({ related_properties: related as string[] | null });
+
+    expect(screen.queryByText(/^Related propert/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Edit in DX" })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/components/CheckResultDrawer.test.tsx
+++ b/src/components/CheckResultDrawer.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 
 import { CheckResultDrawer } from "./CheckResultDrawer";
 import { LevelBasedScorecardCheck } from "../api";
+import { COLORS } from "../styles";
 
 const check: LevelBasedScorecardCheck = {
   id: "rcw3pkmrxp8j",
@@ -55,6 +56,16 @@ describe("CheckResultDrawer", () => {
     expect(screen.getByText("Related properties:")).toBeInTheDocument();
     expect(screen.getByText("scaling-thresholds")).toBeInTheDocument();
     expect(screen.getByText("task-count")).toBeInTheDocument();
+  });
+
+  it("sets an explicit text color on the property chip so dark themes stay legible", () => {
+    renderDrawer({
+      related_properties: ["internal-dependency-documentation"],
+    });
+
+    expect(
+      screen.getByText("internal-dependency-documentation")
+    ).toHaveStyle({ color: COLORS.GRAY_700 });
   });
 
   it("offers an edit affordance for the related properties", async () => {

--- a/src/components/CheckResultDrawer.tsx
+++ b/src/components/CheckResultDrawer.tsx
@@ -99,7 +99,7 @@ export function CheckResultDrawer({
             )}
           </Box>
 
-          {check.related_property && (
+          {!!check.related_properties?.length && (
             <Box
               sx={{
                 paddingTop: 16,
@@ -109,18 +109,32 @@ export function CheckResultDrawer({
                 gridGap: 16,
               }}
             >
-              <span>
-                Related property:{" "}
-                <code
-                  style={{
-                    backgroundColor: COLORS.GRAY_100,
-                    padding: `4px 8px`,
-                    borderRadius: "4px",
-                  }}
-                >
-                  {check.related_property}
-                </code>
-              </span>
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  flexWrap: "wrap",
+                  gridGap: 8,
+                }}
+              >
+                <span>
+                  {check.related_properties.length === 1
+                    ? "Related property:"
+                    : "Related properties:"}
+                </span>
+                {check.related_properties.map((relatedProperty) => (
+                  <code
+                    key={relatedProperty}
+                    style={{
+                      backgroundColor: COLORS.GRAY_100,
+                      padding: `4px 8px`,
+                      borderRadius: "4px",
+                    }}
+                  >
+                    {relatedProperty}
+                  </code>
+                ))}
+              </Box>
               <Button
                 variant="outlined"
                 size="small"

--- a/src/components/CheckResultDrawer.tsx
+++ b/src/components/CheckResultDrawer.tsx
@@ -127,6 +127,7 @@ export function CheckResultDrawer({
                     key={relatedProperty}
                     style={{
                       backgroundColor: COLORS.GRAY_100,
+                      color: COLORS.GRAY_700,
                       padding: `4px 8px`,
                       borderRadius: "4px",
                     }}


### PR DESCRIPTION
Two rendering defects in scorecard check results, found by comparing the plugin's output against the DX web UI for the same entity, plus a follow-on contrast fix.

### Custom output units were pluralised twice

`formatCustomOutputValue` passed the author-supplied `unit` through `pluralize()`, which appends `s` to anything outside its special-case list. Units are already written in their intended form, so they came out doubled:

| Unit configured in DX | Before | After |
| --- | --- | --- |
| `trace metrics` | `4 trace metricss` | `4 trace metrics` |
| `chars` | `89 charss` | `89 chars` |
| `monitors` | `71 monitorss` | `71 monitors` |
| `% time > 90% util` | `0.00 % time > 90% utils` | `0.00 % time > 90% util` |
| | <img width="112" height="30" alt="image" src="https://github.com/user-attachments/assets/a6358bb1-9a07-4abd-b983-388d06275e82" /> | <img width="111" height="37" alt="image" src="https://github.com/user-attachments/assets/386b20ef-5580-4654-82b5-2a657faafe07" /> <br><sub><sup>screenshot taken with different data,<br>count difference expected</sup></sub> |

The unit is now rendered verbatim, matching how DX's own UI displays it. `pluralize()` still serves the `duration_*` output types, whose units are hardcoded singulars (`second`, `minute`, …), so `1 day` / `3 days` behaviour is unchanged.

### The related-property section never rendered

`entities.scorecards` returns `related_properties` as an array of property identifiers. The type and the drawer both expected a singular `related_property` string, which no response contains — so the "Related property / Edit in DX" block was dead code and never appeared for any check, on any entity.

Verified against a live API response: of 18 checks on one scorecard, 9 carried a `related_properties` value and none had a `related_property` key. The field is now correct and every entry in the array is rendered, with the label switching between singular and plural on count.

| Before | After |
| -- | -- |
| <img width="485" height="646" alt="image" src="https://github.com/user-attachments/assets/4b282811-17a6-4d27-bf79-ebde4be6efd7" /> | <img width="495" height="538" alt="image" src="https://github.com/user-attachments/assets/038768dc-169a-4696-b8db-d51f1741e9b1" /> |


### Related-property chips were illegible on dark themes

Once the section above started rendering, the chip turned out to set a light `background-color` while leaving `color` inherited — near-white text on `#F3F4F6`, a contrast ratio of 1.1:1 under a dark theme. It now pairs the background with an explicit foreground, as `CheckResultBadge` already does for its status colours, giving 9.4:1.

<img width="484" height="543" alt="image" src="https://github.com/user-attachments/assets/df216d11-931c-4a28-85eb-97b66f9b416d" />

### Also included

- `CustomOutputOptions.unit` was typed as the string literal `"string"` rather than `string`, making any real unit value a type error.
- Unit tests for `CheckResultBadge` and `CheckResultDrawer` covering the above. These are the first component tests in the package; each one was confirmed to fail against the unfixed code.

### Testing

`yarn tsc`, `yarn lint`, `yarn format:check`, `yarn test` and `yarn build` all pass. Also verified in a real Backstage instance (Backstage 1.51, dark theme) by installing the packed tarball, where the badge text and the related-property row both render as expected.

<!--
### Note on a couple of things left out

A few other fields in the `entities.scorecards` payload are still unused by the plugin, which I've left alone as out of scope but are worth flagging:

- `exemption_expires_at` — a check with a live exemption is failing but excused, and currently renders as an ordinary red FAIL with no indication.
- `ordering` — checks render in array order, which happens to match `ordering` today but isn't guaranteed to.
- `response_metadata.next_cursor` — `scorecards()` requests `limit: 10` without pagination, so an entity with more than ten scorecards silently loses the rest.

Happy to open separate issues or PRs for any of these.
-->

---

<sub><sup>These changes were written with [Claude Code](https://claude.com/claude-code) and reviewed by me before submitting.</sup></sub>